### PR TITLE
Add "page intro" pattern

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env", "@babel/react"]
+  "presets": ["@babel/preset-env", "@babel/react"],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
 }

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-library": "webpack --config webpack.library.js",
     "build": "yarn build-library && yarn build-site",
     "jslint": "./node_modules/.bin/eslint -c .eslintrc.json --ext .js --ext .jsx src",
-    "test": "jest && npm run jslint",
+    "test": "npm run jslint && jest",
     "test-watch": "jest --watch"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",
+    "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",

--- a/src/app/components.jsx
+++ b/src/app/components.jsx
@@ -10,6 +10,7 @@ import Facets from '../components/facets';
 import { treeData, flattenedPaths } from './common/tree-data';
 import lipsum from './common/lipsum';
 import facetData from './common/facetData';
+import PageIntro from '../components/page-intro';
 
 class MainSearchWrapper extends Component {
   constructor(props) {
@@ -40,6 +41,21 @@ const components = [
     purpose: 'Advertise a specific dataset of the website and provide searchable access to it.',
     props: {
       namespace: 'uniref',
+    },
+  },
+  {
+    name: 'Page intro',
+    component: PageIntro,
+    function:
+      'Tell users a bit about the area of the website that they are on with links to further information',
+    purpose:
+      'People might land on areas of the website they don’t know much about. The intro is a place they can get some contextual help, some introductory info and links to further help, information and downloads',
+    props: {
+      title: 'UniProtKB',
+      resultsCount: 1000,
+      children:
+        'UniProtKB consists of two sections:Reviewed (Swiss-Prot) - Manually annotated Records with information extracted from literature and curator-evaluated computational analysis. Unreviewed (TrEMBL) - Computationally analyzed. Records that await full manual annotation. The UniProt Knowledgebase (UniProtKB) is the central hub for the collection of functional information on proteins, with accurate, consistent and rich annotation. In addition to capturing the core data mandatory for each UniProtKB entry (mainly, the amino acid sequence, protein name or description, taxonomic data and citation information), as much annotation information as possible is added.',
+      links: [{ title: 'Help', icon: '', destination: '' }],
     },
   },
   {

--- a/src/components/__tests__/__snapshots__/page-intro.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/page-intro.spec.jsx.snap
@@ -22,7 +22,7 @@ exports[`PageIntro component should render 1`] = `
     </small>
   </h2>
   <div
-    className="intro-content"
+    className="intro-content false"
   >
     <div>
       Some content

--- a/src/components/__tests__/__snapshots__/page-intro.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/page-intro.spec.jsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageIntro component should render 1`] = `
+<div
+  className="page-intro"
+>
+  <h2>
+    <button
+      className="dropdown"
+      onClick={[Function]}
+      type="button"
+    >
+      <test-file-stub />
+       
+      Title
+    </button>
+    <small>
+       
+      1,000
+       
+      results
+    </small>
+  </h2>
+  <div
+    className="intro-content"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  >
+    <div>
+      Some content
+    </div>
+    <div
+      className="intro-links"
+    />
+  </div>
+</div>
+`;

--- a/src/components/__tests__/__snapshots__/page-intro.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/page-intro.spec.jsx.snap
@@ -23,11 +23,6 @@ exports[`PageIntro component should render 1`] = `
   </h2>
   <div
     className="intro-content"
-    style={
-      Object {
-        "display": "none",
-      }
-    }
   >
     <div>
       Some content

--- a/src/components/__tests__/page-intro.spec.jsx
+++ b/src/components/__tests__/page-intro.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import PageIntro from '../page-intro';
+
+describe('PageIntro component', () => {
+  test('should render', () => {
+    const count = 1000;
+
+    const component = renderer
+      .create(
+        <PageIntro title="Title" resultsCount={count}>
+          <div>Some content</div>
+        </PageIntro>,
+      )
+      .toJSON();
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,3 +7,4 @@ export { default as Autocomplete } from './autocomplete';
 export { default as MainSearch } from './main-search';
 export { default as DataTable } from './data-table';
 export { default as Facets } from './facets';
+export { default as PageIntro } from './page-intro';

--- a/src/components/page-intro.jsx
+++ b/src/components/page-intro.jsx
@@ -7,12 +7,7 @@ import ChevronDown from '../svg/chevron-down.svg';
 import ChevronUp from '../svg/chevron-up.svg';
 
 class PageIntro extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showContent: false,
-    };
-  }
+  state = { showContent: false };
 
   render() {
     const {

--- a/src/components/page-intro.jsx
+++ b/src/components/page-intro.jsx
@@ -36,7 +36,9 @@ results
           )}
         </h2>
 
-        <div className="intro-content" style={{ display: showContent ? 'block' : 'none' }}>
+        <div
+          className={showContent ? 'intro-content intro-content--display-content' : 'intro-content'}
+        >
           {children}
           <div className="intro-links">
             {links.map(link => (

--- a/src/components/page-intro.jsx
+++ b/src/components/page-intro.jsx
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { formatLargeNumber } from '../utils';
+import '../styles/components/page-intro.scss';
+import ChevronDown from '../svg/chevron-down.svg';
+import ChevronUp from '../svg/chevron-up.svg';
+
+class PageIntro extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showContent: false,
+    };
+  }
+
+  render() {
+    const {
+      title, resultsCount, children, links,
+    } = this.props;
+    const { showContent } = this.state;
+    return (
+      <div className="page-intro">
+        <h2>
+          <button
+            type="button"
+            onClick={() => this.setState({ showContent: !showContent })}
+            className="dropdown"
+          >
+            {showContent ? <ChevronUp /> : <ChevronDown />}
+            {' '}
+            {title}
+          </button>
+          {resultsCount > 0 && (
+          <small>
+            {' '}
+            {formatLargeNumber(resultsCount)}
+            {' '}
+results
+          </small>
+          )}
+        </h2>
+
+        <div className="intro-content" style={{ display: showContent ? 'block' : 'none' }}>
+          {children}
+          <div className="intro-links">
+            {links.map(link => (
+              <Link to={link.destination} key={link.title}>
+                {link.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+PageIntro.propTypes = {
+  title: PropTypes.string.isRequired,
+  resultsCount: PropTypes.number,
+  children: PropTypes.node.isRequired,
+  links: PropTypes.arrayOf(PropTypes.shape({})),
+};
+
+PageIntro.defaultProps = {
+  resultsCount: 0,
+  links: [],
+};
+
+export default PageIntro;

--- a/src/components/page-intro.jsx
+++ b/src/components/page-intro.jsx
@@ -37,7 +37,7 @@ results
         </h2>
 
         <div
-          className={showContent ? 'intro-content intro-content--display-content' : 'intro-content'}
+          className={`intro-content ${showContent && 'intro-content--display-content'}`}
         >
           {children}
           <div className="intro-links">

--- a/src/styles/components/page-intro.scss
+++ b/src/styles/components/page-intro.scss
@@ -1,0 +1,26 @@
+@import "../settings";
+@import "../colours";
+
+.page-intro {
+  .intro-content {
+    -webkit-column-count: 2; /* Chrome, Safari, Opera */
+    -moz-column-count: 2; /* Firefox */
+    column-count: 2;
+  }
+  .intro-links {
+    text-align: right;
+    a {
+      margin-right: $global-margin;
+    }
+  }
+  button {
+    cursor: pointer;
+    color: $colour-black;
+  }
+  button:focus {
+    outline: none;
+  }
+  small {
+    color: $colour-black;
+  }
+}

--- a/src/styles/components/page-intro.scss
+++ b/src/styles/components/page-intro.scss
@@ -6,6 +6,10 @@
     -webkit-column-count: 2; /* Chrome, Safari, Opera */
     -moz-column-count: 2; /* Firefox */
     column-count: 2;
+    display: none;
+    &--display-content {
+      display: block;
+    }
   }
   .intro-links {
     text-align: right;

--- a/src/styles/components/page-intro.scss
+++ b/src/styles/components/page-intro.scss
@@ -20,9 +20,9 @@
   button {
     cursor: pointer;
     color: $colour-black;
-  }
-  button:focus {
-    outline: none;
+    &:focus {
+      outline: none;
+    }
   }
   small {
     color: $colour-black;

--- a/src/styles/components/page-intro.scss
+++ b/src/styles/components/page-intro.scss
@@ -3,8 +3,6 @@
 
 .page-intro {
   .intro-content {
-    -webkit-column-count: 2; /* Chrome, Safari, Opera */
-    -moz-column-count: 2; /* Firefox */
     column-count: 2;
     display: none;
     &--display-content {

--- a/src/svg/chevron-down.svg
+++ b/src/svg/chevron-down.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
+    <title>Icons/Chevron down</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons/Chevron-down" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="chevron-down" transform="translate(0.000000, 3.000000)" fill="#000000" fill-rule="nonzero">
+            <path d="M6.45754795,8.26178995 L0.245671233,2.04988128 C-0.0539223744,1.75028767 -0.0539223744,1.26457078 0.245671233,0.965009132 L0.970187215,0.240493151 C1.26926941,-0.0585890411 1.75399543,-0.0591643836 2.05378082,0.239214612 L7,5.16226027 L11.9461872,0.239214612 C12.2459726,-0.0591643836 12.7306986,-0.0585890411 13.0297808,0.240493151 L13.7542968,0.965009132 C14.0538904,1.26460274 14.0538904,1.75031963 13.7542968,2.04988128 L7.54245205,8.26178995 C7.24285845,8.5613516 6.75714155,8.5613516 6.45754795,8.26178995 Z" id="Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/src/svg/chevron-up.svg
+++ b/src/svg/chevron-up.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
+    <title>Icons/Chevron down Copy</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons/Chevron-down-Copy" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="chevron-down" transform="translate(7.000000, 7.500000) rotate(-180.000000) translate(-7.000000, -7.500000) translate(0.000000, 3.000000)" fill="#000000" fill-rule="nonzero">
+            <path d="M6.45754795,8.26178995 L0.245671233,2.04988128 C-0.0539223744,1.75028767 -0.0539223744,1.26457078 0.245671233,0.965009132 L0.970187215,0.240493151 C1.26926941,-0.0585890411 1.75399543,-0.0591643836 2.05378082,0.239214612 L7,5.16226027 L11.9461872,0.239214612 C12.2459726,-0.0591643836 12.7306986,-0.0585890411 13.0297808,0.240493151 L13.7542968,0.965009132 C14.0538904,1.26460274 14.0538904,1.75031963 13.7542968,2.04988128 L7.54245205,8.26178995 C7.24285845,8.5613516 6.75714155,8.5613516 6.45754795,8.26178995 Z" id="Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/webpack.library.js
+++ b/webpack.library.js
@@ -50,6 +50,20 @@ module.exports = [
             },
           ],
         },
+        {
+          test: /\.svg$/,
+          use: [
+            {
+              loader: 'babel-loader',
+            },
+            {
+              loader: 'react-svg-loader',
+              options: {
+                jsx: true, // true outputs JSX tags
+              },
+            },
+          ],
+        },
       ],
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,17 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.2.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.2.tgz#fff31a7b2f2f3dad23ef8e01be45b0d5c2fc0132"
+  integrity sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==
+  dependencies:
+    "@babel/types" "^7.3.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -88,6 +99,17 @@
     "@babel/helper-hoist-variables" "^7.0.0"
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
+
+"@babel/helper-create-class-features-plugin@^7.3.0":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.2.tgz#ba1685603eb1c9f2f51c9106d5180135c163fe73"
+  integrity sha512-tdW8+V8ceh2US4GsYdNVNoohq5uVwOf9k6krjwW4E1lINcHgttnWcNqgdoessn12dAy8QkbezlbQh2nXISNY+A==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.2.3"
 
 "@babel/helper-define-map@^7.1.0":
   version "7.1.0"
@@ -195,6 +217,16 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-replace-supers@^7.2.3":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz#19970020cf22677d62b3a689561dbd9644d8c5e5"
+  integrity sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.2.3"
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
@@ -243,6 +275,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
   integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
 
+"@babel/parser@^7.2.3":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.2.tgz#95cdeddfc3992a6ca2a1315191c1679ca32c55cd"
+  integrity sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==
+
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
@@ -251,6 +288,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
+
+"@babel/plugin-proposal-class-properties@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.0.tgz#272636bc0fa19a0bc46e601ec78136a173ea36cd"
+  integrity sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.3.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
@@ -657,10 +702,34 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@^7.2.3":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
+  integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.2.2"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.2.3"
+    "@babel/types" "^7.2.2"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
 "@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.6", "@babel/types@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.0.tgz#7941c5b2d8060e06f9601d6be7c223eef906d5d8"
   integrity sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.2.2", "@babel/types@^7.3.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.2.tgz#424f5be4be633fff33fb83ab8d67e4a8290f5a2f"
+  integrity sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"


### PR DESCRIPTION
Adding a pattern to display namespace information at the top of results pages. The name of the namespace works as a trigger to toggle the display of extra information, as well as a list of links (internal or external).

This branch is required before merging of `uniprot-website`