### PR TITLE
Trm 22818/annotation score visualisation

### DIFF
--- a/src/components/__tests__/__snapshots__/doughnut-chart.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/doughnut-chart.spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DoughnutChart component should render 1`] = `
-<div
+<span
   className="doughnut-chart--medium colour-light-grey"
 >
-  <div
+  <span
     className="doughnut-chart--medium__left-wrap"
   >
-    <div
+    <span
       className="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
       style={
         Object {
@@ -15,11 +15,11 @@ exports[`DoughnutChart component should render 1`] = `
         }
       }
     />
-  </div>
-  <div
+  </span>
+  <span
     className="doughnut-chart--medium__right-wrap"
   >
-    <div
+    <span
       className="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
       style={
         Object {
@@ -27,14 +27,14 @@ exports[`DoughnutChart component should render 1`] = `
         }
       }
     />
-  </div>
-  <div
+  </span>
+  <span
     className="doughnut-chart--medium__inner-circle"
     style={Object {}}
   >
     <span>
       Some content
     </span>
-  </div>
-</div>
+  </span>
+</span>
 `;

--- a/src/components/__tests__/__snapshots__/tile.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/tile.spec.jsx.snap
@@ -19,7 +19,7 @@ exports[`Tile component should render 1`] = `
 
 exports[`Tile component should render small tile 1`] = `
 <div
-  className="tile tile--small"
+  className="tile tile--uniref tile--small"
 >
   <h3
     className="tile__header"

--- a/src/components/__tests__/tile.spec.jsx
+++ b/src/components/__tests__/tile.spec.jsx
@@ -10,7 +10,9 @@ describe('Tile component', () => {
     expect(component).toMatchSnapshot();
   });
   test('should render small tile', () => {
-    const component = renderer.create(<Tile title="Tile title" small />).toJSON();
+    const component = renderer
+      .create(<Tile title="Tile title" small namespace="uniref" />)
+      .toJSON();
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/doughnut-chart.jsx
+++ b/src/components/doughnut-chart.jsx
@@ -16,32 +16,32 @@ const DoughnutChart = ({
     leftTransformerDegree = '0deg';
   }
   return (
-    <div className={`doughnut-chart--${size} ${bgColorClass}`}>
-      <div className={`doughnut-chart--${size}__left-wrap`}>
-        <div
+    <span className={`doughnut-chart--${size} ${bgColorClass}`}>
+      <span className={`doughnut-chart--${size}__left-wrap`}>
+        <span
           className={`doughnut-chart--${size}__left-wrap__loader ${colorClass}`}
           style={{
             transform: `rotate(${leftTransformerDegree})`,
           }}
         />
-      </div>
-      <div className={`doughnut-chart--${size}__right-wrap`}>
-        <div
+      </span>
+      <span className={`doughnut-chart--${size}__right-wrap`}>
+        <span
           className={`doughnut-chart--${size}__right-wrap__loader ${colorClass}`}
           style={{
             transform: `rotate(${rightTransformerDegree})`,
           }}
         />
-      </div>
-      <div className={`doughnut-chart--${size}__inner-circle`} style={{}}>
+      </span>
+      <span className={`doughnut-chart--${size}__inner-circle`} style={{}}>
         {children || (
         <span>
           {percent}
 %
         </span>
         )}
-      </div>
-    </div>
+      </span>
+    </span>
   );
 };
 

--- a/src/styles/components/bubble.scss
+++ b/src/styles/components/bubble.scss
@@ -1,6 +1,6 @@
-@import "../settings";
-@import "../colours";
-@import "../common/utils";
+@import '../settings';
+@import '../colours';
+@import '../common/utils';
 
 @mixin bubble($size) {
   display: inline-block;
@@ -8,6 +8,7 @@
   color: $colour-white;
   border-radius: 50%;
   text-align: center;
+  vertical-align: middle;
   width: $size;
   height: $size;
   line-height: $size;

--- a/src/styles/components/doughnut-chart.scss
+++ b/src/styles/components/doughnut-chart.scss
@@ -1,6 +1,6 @@
-@import "../settings";
-@import "../colours";
-@import "../common/utils";
+@import '../settings';
+@import '../colours';
+@import '../common/utils';
 
 $border-width: 2px;
 
@@ -10,6 +10,7 @@ $border-width: 2px;
   position: relative;
   display: inline-block;
   margin: 0 $global-margin/5;
+  vertical-align: middle;
   width: $size * 2;
   height: $size * 2;
   border-radius: $size;


### PR DESCRIPTION
* Converting `DoughnutChart`'s `div`s to `span`s (so they can be children of paragraph elements).
* `DoughnutCharts` have `vertical-align: middle;` to replicate `Bubble` alignment.
* Gave `Tile` a `namespace` to silence warning during testing.