### PR TITLE
improved styling. flexbox -> grid. bug fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-router-dom": "^5.0.1"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "file-loader": "^2.0.0",
     "foundation-sites": "^6.5.3",
     "history": "^4.10.1",

--- a/src/components/__tests__/__snapshots__/message.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/message.spec.jsx.snap
@@ -3,21 +3,24 @@
 exports[`Message component should render 1`] = `
 <DocumentFragment>
   <div
-    class="message message--info"
+    class="message message--info false"
     role="status"
   >
+    <div
+      class="message__side-border"
+    />
+    <test-file-stub
+      height="1.125em"
+      width="1.125em"
+    />
     <section
       class="message__content"
     >
-      <test-file-stub
-        height="1.125em"
-        width="1.125em"
-      />
-      <small>
+      <h3>
         <div>
           Some content
         </div>
-      </small>
+      </h3>
     </section>
   </div>
 </DocumentFragment>
@@ -26,21 +29,24 @@ exports[`Message component should render 1`] = `
 exports[`Message component should render with a different level 1`] = `
 <DocumentFragment>
   <div
-    class="message message--failure"
+    class="message message--failure false"
     role="status"
   >
+    <div
+      class="message__side-border"
+    />
+    <test-file-stub
+      height="1.125em"
+      width="1.125em"
+    />
     <section
       class="message__content"
     >
-      <test-file-stub
-        height="1.125em"
-        width="1.125em"
-      />
-      <small>
+      <h3>
         <div>
           Some content
         </div>
-      </small>
+      </h3>
     </section>
   </div>
 </DocumentFragment>

--- a/src/components/__tests__/__snapshots__/message.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/message.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Message component should render 1`] = `
 <DocumentFragment>
   <div
-    class="message message--info false"
+    class="message message--info"
     role="status"
   >
     <div
@@ -16,11 +16,11 @@ exports[`Message component should render 1`] = `
     <section
       class="message__content"
     >
-      <h3>
+      <small>
         <div>
           Some content
         </div>
-      </h3>
+      </small>
     </section>
   </div>
 </DocumentFragment>
@@ -29,7 +29,7 @@ exports[`Message component should render 1`] = `
 exports[`Message component should render with a different level 1`] = `
 <DocumentFragment>
   <div
-    class="message message--failure false"
+    class="message message--failure"
     role="status"
   >
     <div
@@ -42,11 +42,11 @@ exports[`Message component should render with a different level 1`] = `
     <section
       class="message__content"
     >
-      <h3>
+      <small>
         <div>
           Some content
         </div>
-      </h3>
+      </small>
     </section>
   </div>
 </DocumentFragment>
@@ -55,7 +55,7 @@ exports[`Message component should render with a different level 1`] = `
 exports[`Message component should render with a subtitle 1`] = `
 <DocumentFragment>
   <div
-    class="message message--info false"
+    class="message message--info"
     role="status"
   >
     <div
@@ -68,11 +68,11 @@ exports[`Message component should render with a subtitle 1`] = `
     <section
       class="message__content"
     >
-      <h3>
+      <small>
         <div>
           Some content
         </div>
-      </h3>
+      </small>
     </section>
     <div
       class="message__subtitle"
@@ -97,11 +97,11 @@ exports[`Message component should render without default icon 1`] = `
     <section
       class="message__content"
     >
-      <h3>
+      <small>
         <div>
           Some content
         </div>
-      </h3>
+      </small>
     </section>
   </div>
 </DocumentFragment>

--- a/src/components/__tests__/__snapshots__/message.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/message.spec.jsx.snap
@@ -51,3 +51,58 @@ exports[`Message component should render with a different level 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`Message component should render with a subtitle 1`] = `
+<DocumentFragment>
+  <div
+    class="message message--info false"
+    role="status"
+  >
+    <div
+      class="message__side-border"
+    />
+    <test-file-stub
+      height="1.125em"
+      width="1.125em"
+    />
+    <section
+      class="message__content"
+    >
+      <h3>
+        <div>
+          Some content
+        </div>
+      </h3>
+    </section>
+    <div
+      class="message__subtitle"
+    >
+      <div>
+        test
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Message component should render without default icon 1`] = `
+<DocumentFragment>
+  <div
+    class="message message--info message--no-icon"
+    role="status"
+  >
+    <div
+      class="message__side-border"
+    />
+    <section
+      class="message__content"
+    >
+      <h3>
+        <div>
+          Some content
+        </div>
+      </h3>
+    </section>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/__tests__/__snapshots__/message.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/message.spec.jsx.snap
@@ -88,7 +88,7 @@ exports[`Message component should render with a subtitle 1`] = `
 exports[`Message component should render without default icon 1`] = `
 <DocumentFragment>
   <div
-    class="message message--info message--no-icon"
+    class="message message--info"
     role="status"
   >
     <div

--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
@@ -18,7 +18,7 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
     ACTGUACTGUACTGU+
   </textarea>
   <div
-    class="message message--failure false"
+    class="message message--failure"
     data-testid="sequence-submission-error"
     role="status"
   >
@@ -32,9 +32,9 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
     <section
       class="message__content"
     >
-      <h3>
+      <small>
         The sequence is invalid
-      </h3>
+      </small>
     </section>
   </div>
 </DocumentFragment>
@@ -49,7 +49,7 @@ exports[`SequenceSubmission should render with sequence is missing error 1`] = `
                 
   </textarea>
   <div
-    class="message message--failure false"
+    class="message message--failure"
     data-testid="sequence-submission-error"
     role="status"
   >
@@ -63,9 +63,9 @@ exports[`SequenceSubmission should render with sequence is missing error 1`] = `
     <section
       class="message__content"
     >
-      <h3>
+      <small>
         The sequence is missing
-      </h3>
+      </small>
     </section>
   </div>
 </DocumentFragment>

--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
@@ -18,20 +18,23 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
     ACTGUACTGUACTGU+
   </textarea>
   <div
-    class="message message--failure"
+    class="message message--failure false"
     data-testid="sequence-submission-error"
     role="status"
   >
+    <div
+      class="message__side-border"
+    />
+    <test-file-stub
+      height="1.125em"
+      width="1.125em"
+    />
     <section
       class="message__content"
     >
-      <test-file-stub
-        height="1.125em"
-        width="1.125em"
-      />
-      <small>
+      <h3>
         The sequence is invalid
-      </small>
+      </h3>
     </section>
   </div>
 </DocumentFragment>
@@ -46,20 +49,23 @@ exports[`SequenceSubmission should render with sequence is missing error 1`] = `
                 
   </textarea>
   <div
-    class="message message--failure"
+    class="message message--failure false"
     data-testid="sequence-submission-error"
     role="status"
   >
+    <div
+      class="message__side-border"
+    />
+    <test-file-stub
+      height="1.125em"
+      width="1.125em"
+    />
     <section
       class="message__content"
     >
-      <test-file-stub
-        height="1.125em"
-        width="1.125em"
-      />
-      <small>
+      <h3>
         The sequence is missing
-      </small>
+      </h3>
     </section>
   </div>
 </DocumentFragment>

--- a/src/components/__tests__/message.spec.jsx
+++ b/src/components/__tests__/message.spec.jsx
@@ -31,4 +31,22 @@ describe('Message component', () => {
     fireEvent.click(getByRole('button'));
     expect(dismissFn).toHaveBeenCalled();
   });
+
+  test('should render with a subtitle', () => {
+    const { asFragment } = render(
+      <Message subtitle={<div>test</div>}>
+        <div>Some content</div>
+      </Message>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('should render without default icon', () => {
+    const { asFragment } = render(
+      <Message noIcon>
+        <div>Some content</div>
+      </Message>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/components/message.jsx
+++ b/src/components/message.jsx
@@ -28,22 +28,20 @@ const Message = ({
     className={classNames(
       'message',
       `message--${level}`,
-      { 'message--no-icon': noIcon || forFullPage },
-      { 'message--no-shadow': noShadow || forFullPage},
-      { 'message--for-full-page': forFullPage },
+      { 'message--no-shadow': noShadow || forFullPage },
+      { 'message--for-full-page': forFullPage }
     )}
     role="status"
     data-testid={dataTestId}
   >
     <div className="message__side-border" />
 
-    {(!noIcon && !forFullPage) && <WarningIcon width={iconSize} height={iconSize} />}
+    {!noIcon && !forFullPage && (
+      <WarningIcon width={iconSize} height={iconSize} />
+    )}
 
     <section className="message__content">
-      {forFullPage
-        ? <h3>{children}</h3>
-        : <small>{children}</small>
-      }
+      {forFullPage ? <h3>{children}</h3> : <small>{children}</small>}
     </section>
 
     {onDismiss && (
@@ -89,7 +87,7 @@ Message.propTypes = {
   /**
    * Custom Test ID
    */
-   'data-testid': PropTypes.string,
+  'data-testid': PropTypes.string,
 };
 
 Message.defaultProps = {

--- a/src/components/message.jsx
+++ b/src/components/message.jsx
@@ -16,23 +16,31 @@ const iconSize = '1.125em';
 const Message = ({
   children,
   level,
+  subtitle,
   onDismiss,
+  noIcon,
   'data-testid': dataTestId,
 }) => (
   <div
-    className={`message message--${level}`}
+    className={`message message--${level} ${noIcon && 'message--no-icon'}`}
     role="status"
     data-testid={dataTestId}
   >
+    <div className="message__side-border" />
+
+    {!noIcon && <WarningIcon width={iconSize} height={iconSize} />}
+
     <section className="message__content">
-      <WarningIcon width={iconSize} height={iconSize} />
-      <small>{children}</small>
+      <h3>{children}</h3>
     </section>
+
     {onDismiss && (
       <button type="button" className="message__dismiss" onClick={onDismiss}>
         <CloseIcon width="10" height="10" />
       </button>
     )}
+
+    {subtitle && <div className="message__subtitle">{subtitle}</div>}
   </div>
 );
 
@@ -46,6 +54,10 @@ Message.propTypes = {
    */
   level: PropTypes.oneOf(['warning', 'failure', 'success', 'info']),
   /**
+   * The content to appear underneath of the main message
+   */
+  subtitle: PropTypes.node,
+  /**
    * Whether the message can be closed or not
    */
   onDismiss: PropTypes.func,
@@ -53,12 +65,18 @@ Message.propTypes = {
    * Custom Test ID
    */
    'data-testid': PropTypes.string,
+  /**
+   * To hide the default message icon
+   */
+  noIcon: PropTypes.bool,
 };
 
 Message.defaultProps = {
   level: MessageLevel.info,
+  subtitle: null,
   onDismiss: null,
   'data-testid': null,
+  noIcon: false,
 };
 
 export default Message;

--- a/src/components/message.jsx
+++ b/src/components/message.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import '../styles/components/message.scss';
 import WarningIcon from '../svg/warning.svg';
 import CloseIcon from '../svg/times.svg';
@@ -19,19 +20,30 @@ const Message = ({
   subtitle,
   onDismiss,
   noIcon,
+  noShadow,
+  forFullPage,
   'data-testid': dataTestId,
 }) => (
   <div
-    className={`message message--${level} ${noIcon && 'message--no-icon'}`}
+    className={classNames(
+      'message',
+      `message--${level}`,
+      { 'message--no-icon': noIcon || forFullPage },
+      { 'message--no-shadow': noShadow || forFullPage},
+      { 'message--for-full-page': forFullPage },
+    )}
     role="status"
     data-testid={dataTestId}
   >
     <div className="message__side-border" />
 
-    {!noIcon && <WarningIcon width={iconSize} height={iconSize} />}
+    {(!noIcon && !forFullPage) && <WarningIcon width={iconSize} height={iconSize} />}
 
     <section className="message__content">
-      <h3>{children}</h3>
+      {forFullPage
+        ? <h3>{children}</h3>
+        : <small>{children}</small>
+      }
     </section>
 
     {onDismiss && (
@@ -62,21 +74,32 @@ Message.propTypes = {
    */
   onDismiss: PropTypes.func,
   /**
-   * Custom Test ID
-   */
-   'data-testid': PropTypes.string,
-  /**
    * To hide the default message icon
    */
   noIcon: PropTypes.bool,
+  /**
+   * To hide the default box shadow
+   */
+  noShadow: PropTypes.bool,
+  /**
+   * To apply any specific styles required for messages shown in
+   * full-page error pages
+   */
+  forFullPage: PropTypes.bool,
+  /**
+   * Custom Test ID
+   */
+   'data-testid': PropTypes.string,
 };
 
 Message.defaultProps = {
   level: MessageLevel.info,
   subtitle: null,
   onDismiss: null,
-  'data-testid': null,
   noIcon: false,
+  noShadow: false,
+  forFullPage: false,
+  'data-testid': null,
 };
 
 export default Message;

--- a/src/styles/components/message.scss
+++ b/src/styles/components/message.scss
@@ -17,8 +17,9 @@
 
 .message {
   box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2);
-  padding: 0.5rem 1rem 0.5rem 0.5rem;
   background-color: $colour-sky-white;
+
+  padding: 0.5rem 1rem 0.5rem 0.5rem;
   margin-bottom: $global-margin/2;
 
   display: grid;
@@ -28,7 +29,6 @@
   grid-template-columns: 1rem 1.5rem auto 1rem;
 
   svg {
-    margin-top: 0.5rem;
     grid-area: icon;
   }
 
@@ -37,6 +37,10 @@
     "border  message dismiss"
     ". subtitle .";
     grid-template-columns: 1rem auto 1rem;
+  }
+
+  &--no-shadow {
+    box-shadow: none;
   }
 
   &__side-border {
@@ -62,8 +66,6 @@
   &__dismiss {
     cursor: pointer;
     grid-area: dismiss;
-    display: flex;
-    padding-top: 0.5rem;
   }
 
   &--warning {

--- a/src/styles/components/message.scss
+++ b/src/styles/components/message.scss
@@ -24,19 +24,13 @@
 
   display: grid;
   grid-template-areas:
-    "border icon message dismiss"
-    ". . subtitle .";
-  grid-template-columns: 1rem 1.5rem auto 1rem;
+    'border icon message dismiss'
+    '. . subtitle .';
+  grid-template-columns: 1rem minmax(0, 1.5rem) auto minmax(0, 1rem);
 
   svg {
     grid-area: icon;
-  }
-
-  &--no-icon {
-    grid-template-areas:
-    "border  message dismiss"
-    ". subtitle .";
-    grid-template-columns: 1rem auto 1rem;
+    height: 1.5rem;
   }
 
   &--no-shadow {
@@ -50,10 +44,10 @@
 
   &__content {
     padding-left: 0.5rem;
+    grid-area: message;
 
     h3 {
       color: $colour-weldon-blue;
-      grid-area: message;
     }
   }
 

--- a/src/styles/components/message.scss
+++ b/src/styles/components/message.scss
@@ -1,9 +1,5 @@
 @import '../colours';
 
-@function getMessageBorder($level) {
-  @return 0.25rem solid $level;
-}
-
 @mixin SVGDefinition($level) {
   svg {
     path {
@@ -14,8 +10,8 @@
 
 @mixin getWarningCSS($level) {
   @include SVGDefinition(($level));
-  .message__content {
-    border-left: getMessageBorder($level);
+  .message__side-border {
+    background-color: $level;
   }
 }
 
@@ -24,32 +20,65 @@
   padding: 0.5rem 1rem 0.5rem 0.5rem;
   background-color: $colour-sky-white;
   margin-bottom: $global-margin/2;
-  display: flex;
+
+  display: grid;
+  grid-template-areas:
+    "border icon message dismiss"
+    ". . subtitle .";
+  grid-template-columns: 1rem 1.5rem auto 1rem;
+
+  svg {
+    margin-top: 0.5rem;
+    grid-area: icon;
+  }
+
+  &--no-icon {
+    grid-template-areas:
+    "border  message dismiss"
+    ". subtitle .";
+    grid-template-columns: 1rem auto 1rem;
+  }
+
+  &__side-border {
+    width: 0.25rem;
+    height: auto;
+  }
+
   &__content {
     padding-left: 0.5rem;
-    flex: 1 1 auto;
-    display: flex;
-    svg {
-      margin-right: 0.5rem;
+
+    h3 {
+      color: $colour-weldon-blue;
+      grid-area: message;
     }
+  }
+
+  &__subtitle {
+    margin-left: 1rem;
+    color: $colour-weldon-blue;
+    grid-area: subtitle;
+  }
+
+  &__dismiss {
+    cursor: pointer;
+    grid-area: dismiss;
+    display: flex;
+    padding-top: 0.5rem;
   }
 
   &--warning {
     @include getWarningCSS($colour-warning);
   }
+
   &--failure {
     @include getWarningCSS($colour-failure);
   }
+
   &--success {
     @include getWarningCSS($colour-success);
   }
+
   &--info {
     @include getWarningCSS($colour-info);
-  }
-
-  &__dismiss {
-    text-align: center;
-    cursor: pointer;
-    flex: 0 1 1rem;
   }
 }

--- a/src/styles/components/message.scss
+++ b/src/styles/components/message.scss
@@ -26,7 +26,7 @@
   grid-template-areas:
     'border icon message dismiss'
     '. . subtitle .';
-  grid-template-columns: 1rem minmax(0, 1.5rem) auto minmax(0, 1rem);
+  grid-template-columns: 1rem minmax(0, max-content) auto minmax(0, max-content);
 
   svg {
     grid-area: icon;

--- a/stories/Message.stories.jsx
+++ b/stories/Message.stories.jsx
@@ -36,11 +36,11 @@ const subtitle = (
   </Fragment>
 );
 
-export const withSubtitle = () => (
+export const forFullPageErrors = () => (
   <Message
     level="warning"
     subtitle={subtitle}
-    noIcon
+    forFullPage
   >
     {getLipsumSentences()}
   </Message>

--- a/stories/Message.stories.jsx
+++ b/stories/Message.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Message } from '../src/components';
 import { getLipsumSentences } from '../src/mock-data/lipsum';
@@ -26,4 +26,22 @@ export const failureMessage = () => (
 );
 export const successMessage = () => (
   <Message level="success">{getLipsumSentences()}</Message>
+);
+
+const subtitle = (
+  <Fragment>
+    Try using <a href="#">BLAST</a>, <a href="#">Align</a>
+    , <a href="#">ID Mapping/Retrieve</a> or{' '}
+    <a href="#">Peptide Search to begin</a>
+  </Fragment>
+);
+
+export const withSubtitle = () => (
+  <Message
+    level="warning"
+    subtitle={subtitle}
+    noIcon
+  >
+    {getLipsumSentences()}
+  </Message>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3692,7 +3692,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==


### PR DESCRIPTION
This was requested by Austra to match the newer designs from the mock-ups with the message component. Here is a summary of what is done in this PR:

- There was a bug here where a long line of text would shrink the message icon on the left-side of the text to a point that it was almost invisible. I fixed it first using flexbox settings, but then completely moved to grids.
- The icon on the left needed better margin settings.
- The dismiss button on the right was vertically aligned in the centre. This mean multiple lines of content in the message itself would make the dismiss icon look a bit odd. This is fixed now.
- Adding the second line of content -- as per mock-ups, using flexbox was a little bit tricky, therefore switched to the grid.
- Added an option to hide the default icon, whenever needed -- to match the mock-ups.
- Had to create a dummy element to represent the side border on the left side of the message. This was due to using grid, optional icon and a few other cases would make the original `border-left` approach very tricky.
- Used `h3` for the actual message content to match the mock-ups. This inherits some responsive behaviour, just a heads-up.
- Had to add a `no-icon` modifier to accommodate the lack of icon in the grid settings.
- The second line is called `subtitle`, but happy to change it to a better name if anyone has a better suggestion.