### PR TITLE
Table ellipsis alternative

### DIFF
--- a/src/components/__tests__/__snapshots__/data-table.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/data-table.spec.jsx.snap
@@ -10,6 +10,7 @@ exports[`DataTable should render 1`] = `
     >
       <table
         class="data-table  "
+        style="table-layout: auto;"
       >
         <thead
           class="data-table__header"
@@ -19,21 +20,25 @@ exports[`DataTable should render 1`] = `
           >
             <th
               class="data-table__header-cell"
+              style="width: 1.5rem;"
             >
                
             </th>
             <th
               class="data-table__header-cell data-table__header-cell--ascend"
+              style="width: auto;"
             >
               Column 1
             </th>
             <th
               class="data-table__header-cell "
+              style="width: auto;"
             >
               Column 2
             </th>
             <th
               class="data-table__header-cell data-table__header-cell--sortable"
+              style="width: auto;"
             >
               Column 3
             </th>
@@ -52,17 +57,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell data-table__cell--selected"
+              class="data-table__cell data-table__cell--selected "
             >
               foo
             </td>
             <td
-              class="data-table__cell data-table__cell--selected"
+              class="data-table__cell data-table__cell--selected "
             >
               bar
             </td>
             <td
-              class="data-table__cell data-table__cell--selected"
+              class="data-table__cell data-table__cell--selected "
             >
               baz
             </td>
@@ -76,17 +81,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               foo
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               bar
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               baz
             </td>
@@ -100,17 +105,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               foo
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               bar
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               baz
             </td>
@@ -124,17 +129,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               foo
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               bar
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               baz
             </td>
@@ -148,17 +153,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               foo
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               bar
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               baz
             </td>
@@ -172,17 +177,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               foo
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               bar
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               baz
             </td>
@@ -196,17 +201,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               foo
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               bar
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               baz
             </td>
@@ -220,17 +225,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               foo
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               bar
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               baz
             </td>
@@ -244,17 +249,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               foo
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               bar
             </td>
             <td
-              class="data-table__cell "
+              class="data-table__cell  "
             >
               baz
             </td>
@@ -268,17 +273,17 @@ exports[`DataTable should render 1`] = `
               />
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               foo
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               bar
             </td>
             <td
-              class="data-table__cell data-table__cell--odd "
+              class="data-table__cell data-table__cell--odd  "
             >
               baz
             </td>

--- a/src/components/__tests__/__snapshots__/data-table.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/data-table.spec.jsx.snap
@@ -9,8 +9,7 @@ exports[`DataTable should render 1`] = `
       class="data-loader__scroll-container"
     >
       <table
-        class="data-table  "
-        style="table-layout: auto;"
+        class="data-table   "
       >
         <thead
           class="data-table__header"
@@ -19,8 +18,7 @@ exports[`DataTable should render 1`] = `
             class="data-table__row"
           >
             <th
-              class="data-table__header-cell"
-              style="width: 1.5rem;"
+              class="data-table__header-cell data-table__header-cell--checkbox"
             >
                
             </th>

--- a/src/components/data-table.jsx
+++ b/src/components/data-table.jsx
@@ -23,20 +23,25 @@ const sharedPropTypes = {
     })
   ).isRequired,
   /**
-   * A callback function that is called whenever a user clicks the header. The column name is
-   * returned upon callback.
+   * Table fixed layout
    */
+  fixedLayout: PropTypes.bool,
 };
 
 const sharedDefaultProps = {
   selectable: false,
+  fixedLayout: false,
 };
 
 const DataTableHead = ({ selectable, columns, onHeaderClick }) => (
   <thead className="data-table__header">
     <tr className="data-table__row">
       {selectable && (
-        <th key="selectable-column" className="data-table__header-cell">
+        <th
+          key="selectable-column"
+          className="data-table__header-cell"
+          style={{ width: '1.5rem' }}
+        >
           {' '}
         </th>
       )}
@@ -56,7 +61,12 @@ const DataTableHead = ({ selectable, columns, onHeaderClick }) => (
           }
         }
         return (
-          <th key={name} className={className} onClick={onClick}>
+          <th
+            key={name}
+            className={className}
+            onClick={onClick}
+            style={{ width: column.width ? column.width : 'auto' }}
+          >
             {label}
           </th>
         );
@@ -93,6 +103,7 @@ const DataTableBody = ({
   selected,
   getIdKey,
   selectable,
+  fixedLayout,
 }) => (
   <tbody className="data-table__table__body">
     {data.map((row, index) => {
@@ -111,16 +122,13 @@ const DataTableBody = ({
             </td>
           )}
           {columns.map(column => (
-            <td key={`${id}-${column.name}`} className={`${className}`}>
-              {/* Here we can't apply the ellipsis styling directly to the td
-                because of table-layout */
-              column.ellipsis ? (
-                <section className="data-table__ellipsis">
-                  {column.render(row)}
-                </section>
-              ) : (
-                column.render(row)
-              )}
+            <td
+              key={`${id}-${column.name}`}
+              className={`${className} ${
+                fixedLayout ? 'data-table__cell--ellipsis' : ''
+              }`}
+            >
+              {column.render(row)}
             </td>
           ))}
         </tr>
@@ -165,6 +173,7 @@ const DataTable = ({
   onHeaderClick,
   density,
   propsForTable,
+  fixedLayout,
 }) => (
   <table
     className={`data-table ${
@@ -174,6 +183,7 @@ const DataTable = ({
         ? ` ${propsForTable.className}`
         : ''
     }`}
+    style={{ tableLayout: fixedLayout ? 'fixed' : 'auto' }}
     {...propsForTable}
   >
     <DataTableHead
@@ -188,6 +198,7 @@ const DataTable = ({
       selected={selected}
       getIdKey={getIdKey}
       selectable={selectable}
+      fixedLayout={fixedLayout}
     />
   </table>
 );

--- a/src/components/data-table.jsx
+++ b/src/components/data-table.jsx
@@ -111,8 +111,16 @@ const DataTableBody = ({
             </td>
           )}
           {columns.map(column => (
-            <td key={`${id}-${column.name}`} className={className}>
-              {column.render(row)}
+            <td key={`${id}-${column.name}`} className={`${className}`}>
+              {/* Here we can't apply the ellipsis styling directly to the td
+                because of table-layout */
+              column.ellipsis ? (
+                <section className="data-table__ellipsis">
+                  {column.render(row)}
+                </section>
+              ) : (
+                column.render(row)
+              )}
             </td>
           ))}
         </tr>

--- a/src/components/data-table.jsx
+++ b/src/components/data-table.jsx
@@ -39,8 +39,7 @@ const DataTableHead = ({ selectable, columns, onHeaderClick }) => (
       {selectable && (
         <th
           key="selectable-column"
-          className="data-table__header-cell"
-          style={{ width: '1.5rem' }}
+          className="data-table__header-cell data-table__header-cell--checkbox"
         >
           {' '}
         </th>
@@ -182,8 +181,7 @@ const DataTable = ({
       propsForTable && propsForTable.className
         ? ` ${propsForTable.className}`
         : ''
-    }`}
-    style={{ tableLayout: fixedLayout ? 'fixed' : 'auto' }}
+    } ${fixedLayout ? 'data-table--fixed' : ''}`}
     {...propsForTable}
   >
     <DataTableHead

--- a/src/decorators/DataDecorator.jsx
+++ b/src/decorators/DataDecorator.jsx
@@ -21,7 +21,6 @@ const DataDecorator = ({ children, ...props }) => {
     {
       label: 'Column 2',
       name: 'content2',
-      ellipsis: true,
       render: row => row.content2,
     },
     {
@@ -34,6 +33,7 @@ const DataDecorator = ({ children, ...props }) => {
       label: 'Column 4',
       name: 'content4',
       render: row => row.content4,
+      width: '40vw',
       sortable: true,
     },
     {

--- a/src/decorators/DataDecorator.jsx
+++ b/src/decorators/DataDecorator.jsx
@@ -21,6 +21,7 @@ const DataDecorator = ({ children, ...props }) => {
     {
       label: 'Column 2',
       name: 'content2',
+      ellipsis: true,
       render: row => row.content2,
     },
     {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -61,3 +61,10 @@ $global-right: if($global-text-direction == rtl, left, right);
     }
   }
 }
+
+@mixin ellipsis($max-width) {
+  max-width: $max-width;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -62,8 +62,7 @@ $global-right: if($global-text-direction == rtl, left, right);
   }
 }
 
-@mixin ellipsis($max-width) {
-  max-width: $max-width;
+@mixin ellipsis() {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/styles/components/data-table.scss
+++ b/src/styles/components/data-table.scss
@@ -79,19 +79,8 @@
       text-align: center;
     }
 
-    section.data-table__ellipsis {
-      // Magic numbers to be fine tuned over time
-      @include fs-breakpoints('small') {
-        @include ellipsis(5rem);
-      }
-
-      @include fs-breakpoints('medium') {
-        @include ellipsis(10rem);
-      }
-
-      @include fs-breakpoints('large') {
-        @include ellipsis(20rem);
-      }
+    &--ellipsis {
+      @include ellipsis();
     }
   }
 

--- a/src/styles/components/data-table.scss
+++ b/src/styles/components/data-table.scss
@@ -10,6 +10,14 @@
   text-align: left;
   width: 100%;
 
+  input[type='checkbox'] {
+    margin: 0;
+  }
+
+  &--fixed {
+    table-layout: fixed;
+  }
+
   &__header-cell {
     border: 0;
     padding: 0.25rem 0.5rem;
@@ -48,6 +56,11 @@
         @include chevron(down, $colour-sky-white);
       }
     }
+
+    &--checkbox {
+      // This doesn't have an effect unless `table-layout: fixed`
+      width: 1.5rem;
+    }
   }
 
   &__cell {
@@ -69,6 +82,7 @@
     }
 
     &--checkbox {
+      // Is this still used?
       box-sizing: border-box;
       width: 0;
       padding: 0.8em 1.2em;

--- a/src/styles/components/data-table.scss
+++ b/src/styles/components/data-table.scss
@@ -5,7 +5,6 @@
 
 .data-table {
   $self: &;
-
   border: 0;
   border-collapse: collapse;
   text-align: left;
@@ -78,6 +77,21 @@
 
     &--loading {
       text-align: center;
+    }
+
+    section.data-table__ellipsis {
+      // Magic numbers to be fine tuned over time
+      @include fs-breakpoints('small') {
+        @include ellipsis(5rem);
+      }
+
+      @include fs-breakpoints('medium') {
+        @include ellipsis(10rem);
+      }
+
+      @include fs-breakpoints('large') {
+        @include ellipsis(20rem);
+      }
     }
   }
 

--- a/stories/Chips.stories.jsx
+++ b/stories/Chips.stories.jsx
@@ -6,8 +6,8 @@ export default {
   title: 'Core|Chip',
   parameters: {
     purposeFunction: {
-      function: 'Shows a dropdown area when clicked',
-      purpose: 'Allow the user to perform actions',
+      function: 'Can be used to make selections or trigger actions',
+      purpose: 'Display compact discrete information',
     },
   },
 };

--- a/stories/DataTable.stories.jsx
+++ b/stories/DataTable.stories.jsx
@@ -78,4 +78,24 @@ export const dataTableCompact = ({
   />
 );
 
+export const fixedTable = ({
+  data,
+  getIdKey,
+  columns,
+  hasMoreData,
+  onLoadMoreItems,
+}) => (
+  <DataTable
+    {...{
+      data,
+      getIdKey,
+      columns,
+      hasMoreData,
+      onLoadMoreItems,
+    }}
+    selectable
+    fixedLayout
+  />
+);
+
 dataTable.propTypes = DataTable.propTypes;


### PR DESCRIPTION
Add option to use fixed table-layout
- this allows ellipsis to work on table columns
- this also allows users to specify the width of some columns if they want to