### PR TITLE
Handle multiple fasta

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,21 +8,7 @@
     "jest": true
   },
   "rules": {
-    "jsx-a11y/anchor-is-valid": [
-      "error",
-      {
-        "components": ["Link"],
-        "specialLink": ["to", "hrefLeft", "hrefRight"],
-        "aspects": ["noHref", "invalidHref", "preferButton"]
-      }
-    ],
-    "react/jsx-wrap-multilines": "off",
-    "react/no-did-update-set-state": "off",
-    "react/jsx-one-expression-per-line": "off",
     "implicit-arrow-linebreak": "off",
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
-    "react/jsx-filename-extension": "disable",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -34,6 +20,21 @@
           "./src/mock-data/**"
         ]
       }
-    ]
+    ],
+    "no-shadow": "off",
+    "jsx-a11y/anchor-is-valid": [
+      "error",
+      {
+        "components": ["Link"],
+        "specialLink": ["to", "hrefLeft", "hrefRight"],
+        "aspects": ["noHref", "invalidHref", "preferButton"]
+      }
+    ],
+    "react/jsx-wrap-multilines": "off",
+    "react/no-did-update-set-state": "off",
+    "react/jsx-one-expression-per-line": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "react/jsx-filename-extension": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "scripts": {
     "build": "yarn build-library && yarn build-storybook",
     "build-library": "webpack --config webpack.library.js",
-    "jslint": "./node_modules/.bin/eslint -c .eslintrc.json --ext .js --ext .jsx src",
-    "test": "yarn jslint && jest",
+    "test:lint": "eslint -c .eslintrc.json --ext .js --ext .jsx src",
+    "test:unit": "jest",
+    "test": "yarn test:lint && yarn test:unit",
     "test-watch": "jest --watch",
     "release": "yarn build && yarn publish && git push --follow-tags origin master",
     "start": "start-storybook -p 6006 -s ./assets",

--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
@@ -34,7 +34,7 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
       class="message__content"
     >
       <small>
-        Identified 1 sequence to be submitted
+        Your input contains 1 sequence
       </small>
     </section>
   </div>

--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SequenceSubmission should render 1`] = `
   <textarea
     class="sequence-submission-input"
     data-testid="sequence-submission-input"
+    spellcheck="false"
   />
 </DocumentFragment>
 `;
@@ -14,9 +15,29 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
   <textarea
     class="sequence-submission-input"
     data-testid="sequence-submission-input"
+    spellcheck="false"
   >
     ACTGUACTGUACTGU+
   </textarea>
+  <div
+    class="message message--info"
+    role="status"
+  >
+    <div
+      class="message__side-border"
+    />
+    <test-file-stub
+      height="1.125em"
+      width="1.125em"
+    />
+    <section
+      class="message__content"
+    >
+      <small>
+        Identified 1 sequence to be submitted
+      </small>
+    </section>
+  </div>
   <div
     class="message message--failure"
     data-testid="sequence-submission-error"
@@ -33,7 +54,10 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
       class="message__content"
     >
       <small>
-        The sequence is invalid
+        <code>
+          sequence 1
+        </code>
+        : The sequence is invalid
       </small>
     </section>
   </div>
@@ -45,28 +69,9 @@ exports[`SequenceSubmission should render with sequence is missing error 1`] = `
   <textarea
     class="sequence-submission-input"
     data-testid="sequence-submission-input"
+    spellcheck="false"
   >
                 
   </textarea>
-  <div
-    class="message message--failure"
-    data-testid="sequence-submission-error"
-    role="status"
-  >
-    <div
-      class="message__side-border"
-    />
-    <test-file-stub
-      height="1.125em"
-      width="1.125em"
-    />
-    <section
-      class="message__content"
-    >
-      <small>
-        The sequence is missing
-      </small>
-    </section>
-  </div>
 </DocumentFragment>
 `;

--- a/src/components/__tests__/sequence-submission.spec.jsx
+++ b/src/components/__tests__/sequence-submission.spec.jsx
@@ -47,10 +47,15 @@ describe('SequenceSubmission', () => {
     const textarea = queryByTestId('sequence-submission-input');
     fireEvent.change(textarea, { target: { value } });
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({
-      ...validResponse,
-      likelyType: 'na',
-      sequence: value,
-    });
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        ...validResponse,
+        header: '',
+        name: '',
+        sequence: value,
+        likelyType: 'na',
+        raw: value,
+      },
+    ]);
   });
 });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -81,3 +81,4 @@ export { default as SuccessIcon } from '../svg/success.svg';
 
 // Sequence Utilities
 export { formatFASTA, extractNameFromFASTAHeader } from '../sequence-utils';
+export { default as sequenceProcessor } from '../sequence-utils/sequence-processor';

--- a/src/components/search-input.jsx
+++ b/src/components/search-input.jsx
@@ -10,6 +10,7 @@ const SearchInput = ({
   onKeyDown,
   placeholder,
   isLoading = false,
+  ...props
 }) => {
   const inputRef = useRef();
   const focusOnInput = () => {
@@ -25,6 +26,7 @@ const SearchInput = ({
         onKeyDown={onKeyDown}
         placeholder={placeholder}
         ref={inputRef}
+        {...props}
       />
       <span
         data-testid="search-input-suffix"

--- a/src/components/sequence-submission.jsx
+++ b/src/components/sequence-submission.jsx
@@ -93,8 +93,8 @@ const SequenceSubmission = ({ value, onChange, placeholder, defaultValue }) => {
       />
       {processed[0] && processed[0].sequence.length > 10 && (
         <Message level="info">
-          Identified {processed.length} sequence
-          {processed.length === 1 ? '' : 's'} to be submitted
+          Your input contains {processed.length} sequence
+          {processed.length === 1 ? '' : 's'}
         </Message>
       )}
       {errorMessages}

--- a/src/components/sequence-submission.jsx
+++ b/src/components/sequence-submission.jsx
@@ -53,6 +53,33 @@ const SequenceSubmission = ({ value, onChange, placeholder, defaultValue }) => {
       .filter(Boolean);
   }
 
+  const warningMessages = [];
+  if (processed.length > 1) {
+    // loop and match all the sequences together, only once
+    for (let i = 0; i < processed.length; i += 1) {
+      for (let j = i + 1; j < processed.length; j += 1) {
+        const a = processed[i];
+        const b = processed[j];
+        if (a.sequence.toLowerCase() === b.sequence.toLowerCase()) {
+          // use index to name the sequences, because name might be the same
+          warningMessages.push(
+            <Message
+              level="info"
+              data-testid="sequence-submission-warning"
+              // eslint-disable-next-line react/no-array-index-key
+              key={`${i}-${j}`}
+            >
+              Sequences {i + 1}
+              {a.name ? ` (${a.name})` : ''} and {j + 1}
+              {b.name ? ` (${b.name})` : ''} are identical, this might be
+              unintended.
+            </Message>
+          );
+        }
+      }
+    }
+  }
+
   return (
     <>
       <textarea
@@ -71,6 +98,7 @@ const SequenceSubmission = ({ value, onChange, placeholder, defaultValue }) => {
         </Message>
       )}
       {errorMessages}
+      {warningMessages}
     </>
   );
 };

--- a/src/components/sequence-submission.jsx
+++ b/src/components/sequence-submission.jsx
@@ -1,35 +1,22 @@
-import React, { useState, useEffect, useCallback, Fragment } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import validateSequences from '../sequence-utils/sequenceValidator';
+
+import sequenceProcessor from '../sequence-utils/sequence-processor';
 import Message from './message';
+
 import '../styles/components/sequence-submission.scss';
 
 const SequenceSubmission = ({ value, onChange, placeholder, defaultValue }) => {
-  const [error, setError] = useState('');
+  const [processed, setProcessed] = useState([]);
 
   const onChangeWithValidation = useCallback(
     newValue => {
-      // Reset the error value before starting the validation
-      setError('');
-
-      // At the moment we are only supporting one sequence, but we need
-      // to send an array to the validator. Here we are sending an array
-      // and extracting the first result object off the returned results.
-      const result = validateSequences([newValue])[0];
-
-      // If the sequence is shorter than 10-characters, then do not display
-      // ANY error messages, but still include the actual validation results
-      // in the callback response.
-      if (newValue.length > 10 && !result.valid) {
-        setError(result.message);
-      }
+      const processed = sequenceProcessor(newValue);
+      setProcessed(processed);
 
       // Calling the custom 'onChange' callback first
       if (onChange instanceof Function) {
-        onChange({
-          ...result,
-          sequence: newValue,
-        });
+        onChange(processed);
       }
     },
     [onChange]
@@ -43,8 +30,31 @@ const SequenceSubmission = ({ value, onChange, placeholder, defaultValue }) => {
     }
   }, [value, defaultValue, onChangeWithValidation]);
 
+  let errorMessages = null;
+  if (
+    processed.length > 1 ||
+    (processed.length === 1 && processed[0].sequence.length > 10)
+  ) {
+    errorMessages = processed
+      .map(
+        (item, index) =>
+          !item.valid && (
+            <Message
+              level="failure"
+              data-testid="sequence-submission-error"
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+            >
+              <code>{item.name || `sequence ${index + 1}`}</code>:&nbsp;
+              {item.message}
+            </Message>
+          )
+      )
+      .filter(Boolean);
+  }
+
   return (
-    <Fragment>
+    <>
       <textarea
         className="sequence-submission-input"
         value={value}
@@ -52,13 +62,16 @@ const SequenceSubmission = ({ value, onChange, placeholder, defaultValue }) => {
         placeholder={placeholder}
         data-testid="sequence-submission-input"
         defaultValue={defaultValue}
+        spellCheck="false"
       />
-      {error && (
-        <Message level="failure" data-testid="sequence-submission-error">
-          {error}
+      {processed[0] && processed[0].sequence.length > 10 && (
+        <Message level="info">
+          Identified {processed.length} sequence
+          {processed.length === 1 ? '' : 's'} to be submitted
         </Message>
       )}
-    </Fragment>
+      {errorMessages}
+    </>
   );
 };
 

--- a/src/sequence-utils/__test__/index.spec.js
+++ b/src/sequence-utils/__test__/index.spec.js
@@ -1,20 +1,39 @@
 import { extractNameFromFASTAHeader, formatFASTA } from '..';
 
 const fastaSingleSequenceMultipleLines = `
->sp|P00000|Protein description OS=Homo sapiens OX=9606 GN=APP PE=1 SV=3
+>sp|P00000|ID_0 Protein description OS=Homo sapiens OX=9606 GN=APP PE=1 SV=3
 MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTK
 IKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITL
 VMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN
 `;
 
-describe('formatFASTA', () => {
-  it('should format a multiple line sequence', () => {
-    expect(formatFASTA(fastaSingleSequenceMultipleLines)).toEqual(
-      `>sp|P00000|Protein description OS=Homo sapiens OX=9606 GN=APP PE=1 SV=3
+const fastaOneBigLine = `
+>sp|P00000|ID_0 Protein description OS=Homo sapiens OX=9606 GN=APP PE=1 SV=3
+MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN`;
+
+const fastaNoHeaderBadlyCopyPasted = `
+
+MLPGLA LLLLAAWTARALEVPTDGN   AGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKIKT
+
+
+EEISEVKMDAEF
+
+
+`;
+
+const expected = `>sp|P00000|ID_0 Protein description OS=Homo sapiens OX=9606 GN=APP PE=1 SV=3
 MLPGLALLLL AAWTARALEV PTDGNAGLLA EPQIAMFCGR LNMHMNVQNG KWDSDPSGTK
 IKTEEISEVK MDAEFRHDSG YEVHHQKLVF FAEDVGSNKG AIIGLMVGGV VIATVIVITL
-VMLKKKQYTS IHHGVVEVDA AVTPEERHLS KMQQNGYENP TYKFFEQMQN`
-    );
+VMLKKKQYTS IHHGVVEVDA AVTPEERHLS KMQQNGYENP TYKFFEQMQN`;
+
+const expectedNoHeader = `MLPGLALLLL AAWTARALEV PTDGNAGLLA EPQIAMFCGR LNMHMNVQNG KWDSDPSGTK
+IKTEEISEVK MDAEF`;
+
+describe('formatFASTA', () => {
+  it('should format a multiple line sequence', () => {
+    expect(formatFASTA(fastaSingleSequenceMultipleLines)).toEqual(expected);
+    expect(formatFASTA(fastaOneBigLine)).toEqual(expected);
+    expect(formatFASTA(fastaNoHeaderBadlyCopyPasted)).toEqual(expectedNoHeader);
   });
 });
 
@@ -22,6 +41,9 @@ describe('extractNameFromFASTAHeader', () => {
   it('should extract name', () => {
     expect(
       extractNameFromFASTAHeader(fastaSingleSequenceMultipleLines)
-    ).toEqual('P00000');
+    ).toEqual('sp|P00000|ID_0');
+    expect(
+      extractNameFromFASTAHeader(fastaNoHeaderBadlyCopyPasted)
+    ).toBeUndefined();
   });
 });

--- a/src/sequence-utils/__test__/sequenceValidator.spec.js
+++ b/src/sequence-utils/__test__/sequenceValidator.spec.js
@@ -58,6 +58,7 @@ test('should NOT fail if a sequence is too short after clean-up', () => {
     {
       ...validResponse,
       likelyType: 'na',
+      sequence: 'A**C**G**T**U**',
     },
   ];
 
@@ -70,6 +71,7 @@ test('should indicate a valid AA sequence', () => {
     {
       ...validResponse,
       likelyType: 'aa',
+      sequence: 'ARNDCEQGHILKMFPSTWYVXBZJ',
     },
   ];
 
@@ -87,6 +89,7 @@ test('should indicate a valid NA sequence', () => {
     {
       ...validResponse,
       likelyType: 'na',
+      sequence: 'ACGTUACGTUACGTUACGTU',
     },
   ];
 
@@ -104,6 +107,7 @@ test('should indicate AA for an NA sequence with ambiguous codes', () => {
     {
       ...validResponse,
       likelyType: 'aa',
+      sequence: 'ACGTWSMKRYBDHVNZ',
     },
   ];
 
@@ -116,6 +120,7 @@ test('should remove all FASTA description lines', () => {
     {
       ...validResponse,
       likelyType: 'aa',
+      sequence: 'ARNDCEQGHILKMFPSTWYVXBZJ',
     },
   ];
 
@@ -128,10 +133,12 @@ test('should validate an array of multiple sequences', () => {
     {
       ...validResponse,
       likelyType: 'aa',
+      sequence: fastaArray[0],
     },
     {
       ...validResponse,
       likelyType: 'na',
+      sequence: fastaArray[1],
     },
   ];
 
@@ -144,10 +151,12 @@ test('should validate a string that contains multiple sequences', () => {
     {
       ...validResponse,
       likelyType: 'aa',
+      sequence: 'ARNDCEQGHILKMFPSTWYVXBZJ',
     },
     {
       ...validResponse,
       likelyType: 'na',
+      sequence: 'ACGTUACGTUACGTUACGTU',
     },
   ];
 

--- a/src/sequence-utils/sequence-processor.js
+++ b/src/sequence-utils/sequence-processor.js
@@ -1,0 +1,67 @@
+import { commentLineRE, extractNameFromFASTAHeader } from '.';
+import { sequenceValidator } from './sequenceValidator';
+
+const whitespaceRE = /\s+/g;
+
+const getNewSequenceObject = () => ({
+  raw: '',
+  name: '',
+  header: '',
+  sequence: '',
+});
+
+const validate = sequenceObject => {
+  const validation = sequenceValidator(sequenceObject.sequence);
+  return { ...validation, ...sequenceObject };
+};
+
+const sequenceProcessor = rawText => {
+  const sequences = [];
+  let currentSequence = getNewSequenceObject();
+  // eslint-disable-next-line no-restricted-syntax
+  for (const line of rawText.split('\n')) {
+    // for each line
+
+    if (commentLineRE.test(line)) {
+      // if this is a comment line
+
+      if (currentSequence.sequence) {
+        // if we already have sequence data being processed
+        // store current sequence
+        sequences.push(validate(currentSequence));
+
+        // and start new sequence
+        currentSequence = getNewSequenceObject();
+      }
+
+      if (currentSequence.header) {
+        // multiline header
+        currentSequence.header += '\n';
+      } else {
+        // first header line
+        const name = extractNameFromFASTAHeader(line);
+        if (name) {
+          currentSequence.name = name;
+        }
+      }
+      currentSequence.header += line;
+    } else {
+      // if this is a sequence line
+      currentSequence.sequence += line.replace(whitespaceRE, '');
+    }
+
+    // store the raw string
+    if (currentSequence.raw) {
+      currentSequence.raw += '\n';
+    }
+    currentSequence.raw += line;
+  }
+
+  if (currentSequence.raw) {
+    sequences.push(validate(currentSequence));
+  }
+
+  return sequences;
+};
+
+export default sequenceProcessor;

--- a/src/sequence-utils/sequenceValidator.js
+++ b/src/sequence-utils/sequenceValidator.js
@@ -20,29 +20,29 @@ export const validNucleicAcids = [
   // No gaps e.g. - and . are not allowed
 ].join('');
 
-export const errorResponses = {
-  missingSequence: {
+export const errorResponses = Object.freeze({
+  missingSequence: Object.freeze({
     valid: false,
     likelyType: null,
     message: 'The sequence is missing',
-  },
-  invalidSequence: {
+  }),
+  invalidSequence: Object.freeze({
     valid: false,
     likelyType: null,
     message: 'The sequence is invalid',
-  },
-  shortSequence: {
+  }),
+  shortSequence: Object.freeze({
     valid: false,
     likelyType: null,
     message: 'The sequence is too short',
-  },
-};
+  }),
+});
 
-export const validResponse = {
+export const validResponse = Object.freeze({
   valid: true,
   likelyType: null,
   message: null,
-};
+});
 
 // Keep start ^ and end $ anchors in the regex
 // Matches all alphabet letters, except for the letter O (case-insensitive)
@@ -55,7 +55,7 @@ const validCharacters = /^[A-NP-Z*.-]+$/i;
  * @param {string} seq - Sequence
  * @return {Boolean} True if it is likely to be FASTA
  */
-const isFASTA = seq => /.*[>]+/gm.test(seq);
+const isFASTA = seq => /.*[>;]+/gm.test(seq);
 
 /**
  * Prepares a string to be digested by the core validation function.
@@ -65,7 +65,7 @@ const isFASTA = seq => /.*[>]+/gm.test(seq);
  */
 function prepareFASTAString(fasta) {
   return fasta
-    .split(/^>.*\n?$/gm) // split and remove the 'Description' line
+    .split(/^[>;].*\n?$/gm) // split and remove the 'Description' line
     .map(s => s.replace(/\s/g, '')) // remove all of the white-space
     .filter(Boolean); // remove all non-truthy values e.g. null, '', false.
 }
@@ -160,7 +160,7 @@ function guessSequenceType(sequence, threshold) {
  * @param {string} sequence - A sequence
  * @return {string} The likely type either 'aa' or 'na'
  */
-function findLikelyType(sequence) {
+export function findLikelyType(sequence) {
   // 1. Remove all of the non-letter characters, plus N and X
   // 2. If less than 11 usable characters left: unable to guess
   // 3. If more than (by default) 90% ACGTU: Nucleic-Acids
@@ -182,7 +182,7 @@ function findLikelyType(sequence) {
  * @param {string} sequence - A sequence
  * @return {object} The result
  */
-function sequenceValidator(sequence) {
+export function sequenceValidator(sequence) {
   // Sequence was not passed at all
   if (!sequence) {
     return errorResponses.missingSequence;
@@ -230,6 +230,7 @@ function sequenceValidator(sequence) {
   return {
     ...validResponse,
     likelyType,
+    sequence,
   };
 }
 
@@ -256,7 +257,7 @@ function validateSequences(input) {
   }
 
   // This works based on the value of 'sequence', so keep it here instead of top
-  const invalidInputException = `Sequence Validiation function expects an Array<string>|string, but received ${typeof sequence}`;
+  const invalidInputException = `Sequence Validation function expects an Array<string>|string, but received ${typeof sequence}`;
 
   // Otherwise, make sure we have an array to work with
   if (Array.isArray) {

--- a/src/styles/components/sequence-submission.scss
+++ b/src/styles/components/sequence-submission.scss
@@ -5,3 +5,9 @@
   height: 30vh;
   font-family: $font-family-monospace;
 }
+
+@media (min-width: 500px) {
+  .sequence-submission-input {
+    white-space: nowrap;
+  }
+}

--- a/stories/SequenceSubmission.stories.jsx
+++ b/stories/SequenceSubmission.stories.jsx
@@ -22,6 +22,32 @@ export const withInvalidSequenceError = () => (
   />
 );
 
+const multipleSequences1 = `> sequence_1
+ACTGUACTGUACTGU
+> sequence_2
+ACTGAUTTGUATTGUUUGU
+`;
+export const withMultipleSequences = () => (
+  <SequenceSubmission
+    placeholder="Enter a sequence..."
+    defaultValue={multipleSequences1}
+  />
+);
+
+const multipleSequences2 = `> sequence_1
+ACTGUACTGUACTGU
+> sequence_2
+ACTGAUTTGUATTGUUUGU
+> sequence_3
+ACTGUACTGUACTGU
+`;
+export const withMultipleSequencesWarning = () => (
+  <SequenceSubmission
+    placeholder="Enter a sequence..."
+    defaultValue={multipleSequences2}
+  />
+);
+
 export const dynamicallyChangeValue = () => {
   const [sequence, setSequence] = useState('ACTG');
   const [likelyType, setLikelyType] = useState(null);


### PR DESCRIPTION
Group of changes mainly aimed at handling better multiple sequences FASTAs
See [corresponding PR](https://github.com/ebi-uniprot/uniprot-website/pull/166) in uniprot-website
 Directly related:
 - augment validation object to make it a "ParsedSequence" object with `raw` containing the raw sequence, `header` containing the header, `sequence` containing the cleaned-up sequence, and `name` containing the header-extracted NCBI identifier if possible.
   - add `sequenceProcessor` utility function for that.
 - use cleaned up sequence for length validation (instead of raw sequence string)
 - add info messages to report number of detected sequences, and one-to-one identical sequence (if cleaned-up sequence is the same between 2 sequences in a multiple FASTA)
 - add name, or index, of the sequence, when reporting info or error messages
 - provide a function to format FASTA sequence in a "nice" way (chunks of 10 aa, split lines)

Misc:
 - Remove spellcheck SequenceSubmission