### PR TITLE
add ability to optionally display "shadow" of full dataset

### DIFF
--- a/src/components/__tests__/__snapshots__/histogram-x-axis.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/histogram-x-axis.spec.jsx.snap
@@ -30,7 +30,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.71em"
           fill="currentColor"
-          y="3"
+          y="6"
         >
           0
         </text>
@@ -47,7 +47,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.71em"
           fill="currentColor"
-          y="3"
+          y="6"
         >
           5
         </text>
@@ -64,7 +64,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.71em"
           fill="currentColor"
-          y="3"
+          y="6"
         >
           10
         </text>

--- a/src/components/__tests__/__snapshots__/histogram-y-axis.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/histogram-y-axis.spec.jsx.snap
@@ -31,7 +31,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           0
         </text>
@@ -48,7 +48,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           1
         </text>
@@ -65,7 +65,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           2
         </text>
@@ -82,7 +82,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           3
         </text>
@@ -99,7 +99,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           4
         </text>
@@ -116,7 +116,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           5
         </text>
@@ -133,7 +133,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           6
         </text>
@@ -150,7 +150,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           7
         </text>
@@ -167,7 +167,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           8
         </text>
@@ -184,7 +184,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           9
         </text>
@@ -201,7 +201,7 @@ exports[`XAxis component should render with correct tickmarks 1`] = `
         <text
           dy="0.32em"
           fill="currentColor"
-          x="-3"
+          x="-6"
         >
           10
         </text>

--- a/src/components/__tests__/__snapshots__/histogram.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/histogram.spec.jsx.snap
@@ -6,6 +6,36 @@ exports[`HistogramFilter component should render when binSize prop is provided a
     class="histogram"
     data-testid="histogram"
   >
+    <div
+      class="histogram__bar-container"
+      style="height: 300px;"
+    >
+      <div
+        class="histogram histogram__bar histogram__bar--within-range"
+        data-testid="histogram-bar"
+        style="transform: scaleY(0.4); transition-delay: 0ms;"
+      />
+      <div
+        class="histogram histogram__bar histogram__bar--within-range"
+        data-testid="histogram-bar"
+        style="transform: scaleY(0.4); transition-delay: 100ms;"
+      />
+      <div
+        class="histogram histogram__bar histogram__bar--within-range"
+        data-testid="histogram-bar"
+        style="transform: scaleY(0.4); transition-delay: 200ms;"
+      />
+      <div
+        class="histogram histogram__bar histogram__bar--within-range"
+        data-testid="histogram-bar"
+        style="transform: scaleY(0.4); transition-delay: 300ms;"
+      />
+      <div
+        class="histogram histogram__bar histogram__bar--within-range"
+        data-testid="histogram-bar"
+        style="transform: scaleY(0.4); transition-delay: 400ms;"
+      />
+    </div>
     <svg
       height="80"
       style="top: 300px;"
@@ -40,7 +70,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             0.0
           </text>
@@ -57,7 +87,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             0.5
           </text>
@@ -74,7 +104,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             1.0
           </text>
@@ -91,7 +121,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             1.5
           </text>
@@ -108,7 +138,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             2.0
           </text>
@@ -125,7 +155,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             2.5
           </text>
@@ -142,7 +172,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             3.0
           </text>
@@ -159,7 +189,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             3.5
           </text>
@@ -176,7 +206,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             4.0
           </text>
@@ -193,7 +223,7 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             4.5
           </text>
@@ -210,43 +240,13 @@ exports[`HistogramFilter component should render when binSize prop is provided a
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             5.0
           </text>
         </g>
       </g>
     </svg>
-    <div
-      class="histogram__bar-container"
-      style="height: 300px;"
-    >
-      <div
-        class="histogram histogram__bar histogram__bar--within-range"
-        data-testid="histogram-bar"
-        style="transform: scaleY(0.4); transition-delay: 0ms;"
-      />
-      <div
-        class="histogram histogram__bar histogram__bar--within-range"
-        data-testid="histogram-bar"
-        style="transform: scaleY(0.4); transition-delay: 100ms;"
-      />
-      <div
-        class="histogram histogram__bar histogram__bar--within-range"
-        data-testid="histogram-bar"
-        style="transform: scaleY(0.4); transition-delay: 200ms;"
-      />
-      <div
-        class="histogram histogram__bar histogram__bar--within-range"
-        data-testid="histogram-bar"
-        style="transform: scaleY(0.4); transition-delay: 300ms;"
-      />
-      <div
-        class="histogram histogram__bar histogram__bar--within-range"
-        data-testid="histogram-bar"
-        style="transform: scaleY(0.4); transition-delay: 400ms;"
-      />
-    </div>
     <div
       class="erd_scroll_detection_container erd_scroll_detection_container_animation_active"
       style="visibility: hidden; display: inline; width: 0px; height: 0px; z-index: -1; overflow: hidden; margin: 0px; padding: 0px;"
@@ -287,6 +287,21 @@ exports[`HistogramFilter component should render when nBins prop is provided and
     class="histogram"
     data-testid="histogram"
   >
+    <div
+      class="histogram__bar-container"
+      style="height: 300px;"
+    >
+      <div
+        class="histogram histogram__bar histogram__bar--within-range"
+        data-testid="histogram-bar"
+        style="transform: scaleY(1); transition-delay: 0ms;"
+      />
+      <div
+        class="histogram histogram__bar histogram__bar--within-range"
+        data-testid="histogram-bar"
+        style="transform: scaleY(1); transition-delay: 250ms;"
+      />
+    </div>
     <svg
       height="80"
       style="top: 300px;"
@@ -321,7 +336,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             0.0
           </text>
@@ -338,7 +353,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             0.5
           </text>
@@ -355,7 +370,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             1.0
           </text>
@@ -372,7 +387,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             1.5
           </text>
@@ -389,7 +404,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             2.0
           </text>
@@ -406,7 +421,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             2.5
           </text>
@@ -423,7 +438,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             3.0
           </text>
@@ -440,7 +455,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             3.5
           </text>
@@ -457,7 +472,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             4.0
           </text>
@@ -474,7 +489,7 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             4.5
           </text>
@@ -491,28 +506,13 @@ exports[`HistogramFilter component should render when nBins prop is provided and
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-3"
+            x="-6"
           >
             5.0
           </text>
         </g>
       </g>
     </svg>
-    <div
-      class="histogram__bar-container"
-      style="height: 300px;"
-    >
-      <div
-        class="histogram histogram__bar histogram__bar--within-range"
-        data-testid="histogram-bar"
-        style="transform: scaleY(1); transition-delay: 0ms;"
-      />
-      <div
-        class="histogram histogram__bar histogram__bar--within-range"
-        data-testid="histogram-bar"
-        style="transform: scaleY(1); transition-delay: 250ms;"
-      />
-    </div>
     <div
       class="erd_scroll_detection_container erd_scroll_detection_container_animation_active"
       style="visibility: hidden; display: inline; width: 0px; height: 0px; z-index: -1; overflow: hidden; margin: 0px; padding: 0px;"

--- a/src/components/histogram-x-axis.jsx
+++ b/src/components/histogram-x-axis.jsx
@@ -15,11 +15,13 @@ const XAxis = ({ min, max, interval, yPos, width, label }) => {
         .range([0, width]);
       const axis = axisBottom()
         .scale(scale)
-        .tickValues(range(min, max + interval, interval));
+        .tickValues(range(min, max + interval, interval))
+        .tickPadding(6);
       axis.tickSize(0);
       const svg = select(d3Container.current);
       svg.selectAll('*').remove();
       svg.append('g').call(axis);
+
       if (label) {
         svg
           .append('text')

--- a/src/components/histogram-y-axis.jsx
+++ b/src/components/histogram-y-axis.jsx
@@ -8,7 +8,9 @@ const YAxis = ({ scale, height, label }) => {
   const d3Container = useRef(null);
   useEffect(() => {
     if (d3Container.current) {
-      const axis = axisLeft().scale(scale);
+      const axis = axisLeft()
+        .scale(scale)
+        .tickPadding(6);
       axis.tickSize(0);
       const svg = select(d3Container.current);
       svg.selectAll('*').remove();

--- a/src/components/histogram.jsx
+++ b/src/components/histogram.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, Fragment } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { SizeMe } from 'react-sizeme';
 import { scaleLinear } from 'd3-scale';
@@ -82,19 +82,6 @@ const Histogram = ({
     <SizeMe>
       {({ size }) => (
         <div className="histogram" data-testid="histogram">
-          {showAxes && (
-            <Fragment>
-              <XAxis
-                min={min}
-                max={max}
-                interval={binSize}
-                yPos={height}
-                width={size.width}
-                label={xLabel}
-              />
-              <YAxis scale={yScale} height={height} label={yLabel} />
-            </Fragment>
-          )}
           {unfilteredValuesShadow ? (
             <div
               className="histogram__bar-shadow-container"
@@ -139,6 +126,19 @@ const Histogram = ({
               );
             })}
           </div>
+          {showAxes && (
+            <>
+              <XAxis
+                min={min}
+                max={max}
+                interval={binSize}
+                yPos={height}
+                width={size.width}
+                label={xLabel}
+              />
+              <YAxis scale={yScale} height={height} label={yLabel} />
+            </>
+          )}
         </div>
       )}
     </SizeMe>

--- a/src/components/histogram.jsx
+++ b/src/components/histogram.jsx
@@ -21,6 +21,7 @@ const Histogram = ({
   showAxes,
   xLabel,
   yLabel,
+  unfilteredValuesShadow,
 }) => {
   const allValues = unfilteredValues || values;
 
@@ -48,7 +49,7 @@ const Histogram = ({
   }, [binSizeOrNull, maxOrNull, minOrNull, nBinsOrNull, values]);
 
   // Construct bins
-  const [bins, yScale, transformScaleY] = useMemo(() => {
+  const [bins, allBins, yScale, transformScaleY] = useMemo(() => {
     const innerBins = Array(nBins).fill(0);
     const allDataBins = Array(nBins).fill(0);
     values.forEach(value => {
@@ -63,7 +64,7 @@ const Histogram = ({
       .domain([0, domainMax])
       .range([height, 0]);
     const innerTransformScaleY = count => yScale(domainMax - count) / height;
-    return [innerBins, innerYScale, innerTransformScaleY];
+    return [innerBins, allDataBins, innerYScale, innerTransformScaleY];
   }, [getIndex, height, nBins, values, allValues]);
 
   window.yScale = yScale;
@@ -94,6 +95,29 @@ const Histogram = ({
               <YAxis scale={yScale} height={height} label={yLabel} />
             </Fragment>
           )}
+          {unfilteredValuesShadow ? (
+            <div
+              className="histogram__bar-shadow-container"
+              style={{ height, opacity: unfilteredValuesShadow }}
+            >
+              {allBins.map((count, index) => {
+                const withinRange =
+                  selectedRange === null ||
+                  (startIndex <= index && index <= endIndex);
+                return (
+                  <div
+                    key={index} // eslint-disable-line react/no-array-index-key
+                    data-testid="histogram-bar"
+                    className={cn(
+                      'histogram histogram__bar',
+                      withinRange && 'histogram__bar--within-range'
+                    )}
+                    style={{ transform: `scaleY(${transformScaleY(count)})` }}
+                  />
+                );
+              })}
+            </div>
+          ) : null}
           <div className="histogram__bar-container" style={{ height }}>
             {bins.map((count, index) => {
               const withinRange =
@@ -167,6 +191,10 @@ Histogram.propTypes = {
    * Label to appear under the axis
    */
   xLabel: PropTypes.string,
+  /**
+   * Display a shadow of the unfiltered data (opacity value)
+   */
+  unfilteredValuesShadow: PropTypes.number,
 };
 
 Histogram.defaultProps = {
@@ -180,6 +208,7 @@ Histogram.defaultProps = {
   xLabel: null,
   yLabel: null,
   unfilteredValues: undefined,
+  unfilteredValuesShadow: 0,
 };
 
 export default Histogram;

--- a/src/styles/components/histogram.scss
+++ b/src/styles/components/histogram.scss
@@ -20,6 +20,13 @@
     overflow: hidden; // hide overflow caused by the "bouncy" transition
   }
 
+  &__bar-shadow-container {
+    opacity: 0;
+    position: absolute;
+    display: flex;
+    width: 100%;
+  }
+
   &__bar {
     background-color: $colour-platinum;
     display: inline-block;

--- a/stories/Histogram.stories.jsx
+++ b/stories/Histogram.stories.jsx
@@ -51,6 +51,7 @@ const ChangingGaussianComponent = () => {
       max={gaussianMax}
       xLabel="Value"
       yLabel="Frequency"
+      unfilteredValuesShadow={0.1}
     />
   );
 };


### PR DESCRIPTION
In `<Histogram>`:
 - Optionally display a shadow of the full dataset in the back of the actual data
 -> to see check the "changing gaussian" demo in storybook