### PR TITLE
Wire action for when modal opens

### DIFF
--- a/src/components/button-modal.jsx
+++ b/src/components/button-modal.jsx
@@ -10,6 +10,7 @@ const DialogWindow = ({
   height,
   className,
   handleExitModal,
+  onWindowOpen,
   withHeaderCloseButton,
   withFooterCloseButton,
   children,
@@ -20,7 +21,7 @@ const DialogWindow = ({
     title={title}
     withHeaderCloseButton={withHeaderCloseButton}
     withFooterCloseButton={withFooterCloseButton}
-    onWindowOpen={() => null}
+    onWindowOpen={onWindowOpen}
     onWindowClose={handleExitModal}
     withShadow
     className={className}
@@ -35,6 +36,7 @@ DialogWindow.propTypes = {
   width: PropTypes.string.isRequired,
   height: PropTypes.string.isRequired,
   handleExitModal: PropTypes.func.isRequired,
+  onWindowOpen: PropTypes.func,
   withHeaderCloseButton: PropTypes.bool.isRequired,
   withFooterCloseButton: PropTypes.bool.isRequired,
   children: PropTypes.oneOfType([
@@ -45,6 +47,7 @@ DialogWindow.propTypes = {
 
 DialogWindow.defaultProps = {
   className: null,
+  onWindowOpen: () => null,
 };
 
 const ButtonModal = ({
@@ -54,6 +57,7 @@ const ButtonModal = ({
   height,
   withHeaderCloseButton,
   withFooterCloseButton,
+  onWindowOpen,
   children,
 }) => {
   const { displayModal, setDisplayModal, Modal } = useModal(
@@ -77,6 +81,7 @@ const ButtonModal = ({
           height={height}
           withHeaderCloseButton={withHeaderCloseButton}
           withFooterCloseButton={withFooterCloseButton}
+          onWindowOpen={onWindowOpen}
         >
           {children}
         </Modal>
@@ -103,6 +108,8 @@ ButtonModal.propTypes = {
   withHeaderCloseButton: PropTypes.bool,
   /** Display the close button in the footer */
   withFooterCloseButton: PropTypes.bool,
+  /** Executed when the modal opens */
+  onWindowOpen: PropTypes.func,
 };
 
 ButtonModal.defaultProps = {
@@ -110,6 +117,7 @@ ButtonModal.defaultProps = {
   height: '70vh',
   withHeaderCloseButton: false,
   withFooterCloseButton: true,
+  onWindowOpen: () => null,
 };
 
 export default ButtonModal;

--- a/src/components/modal-backdrop.jsx
+++ b/src/components/modal-backdrop.jsx
@@ -10,6 +10,9 @@ const ModalBackdrop = ({
   const bodyTag = document.body;
   bodyTag.classList.add('modal__body');
 
+  // onWindowOpen not used but leads to console warning as added as
+  // attribute. Long term should probably rename prop
+
   // clean-up, when component unmounts.
   useEffect(() => () => bodyTag.classList.remove('modal__body'));
 

--- a/src/components/modal-backdrop.jsx
+++ b/src/components/modal-backdrop.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 const ModalBackdrop = ({
   className,
   handleExitModal,
+  onWindowOpen,
   ...otherProps
 }) => {
   const bodyTag = document.body;
@@ -26,10 +27,12 @@ const ModalBackdrop = ({
 ModalBackdrop.propTypes = {
   className: PropTypes.string,
   handleExitModal: PropTypes.func.isRequired,
+  onWindowOpen: PropTypes.func,
 };
 
 ModalBackdrop.defaultProps = {
   className: null,
+  onWindowOpen: () => null,
 };
 
 export default ModalBackdrop;

--- a/stories/Modal.stories.jsx
+++ b/stories/Modal.stories.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { loremIpsum } from 'lorem-ipsum';
+import { action } from '@storybook/addon-actions';
+
 import { ButtonModal } from '../src/components';
 
 export default {
@@ -14,7 +16,11 @@ export default {
 };
 
 export const modal = () => (
-  <ButtonModal buttonText="click me" title="Example modal window">
+  <ButtonModal
+    buttonText="click me"
+    title="Example modal window"
+    onWindowOpen={action('hello')}
+  >
     {loremIpsum(45)}
   </ButtonModal>
 );


### PR DESCRIPTION
 - Add `onWindowOpen` as an optional prop to be triggered when the modal opens.
 - As the prop starts with "on", there is a warning thrown by React ("Warning: Unknown event handler property `onWindowOpen`...). This warning is not in prod but I think we should sort this out.