### PR TITLE
Optional data loader props

### DIFF
--- a/src/components/__tests__/data-list.spec.jsx
+++ b/src/components/__tests__/data-list.spec.jsx
@@ -1,6 +1,6 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import DataList from '../data-list';
+import { DataListWithLoader as DataList } from '../data-list';
 
 describe('DataList', () => {
   const data = Array.from({ length: 10 }, (_, index) => ({

--- a/src/components/__tests__/data-table.spec.jsx
+++ b/src/components/__tests__/data-table.spec.jsx
@@ -1,6 +1,6 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import DataTable from '../data-table';
+import { DataTableWithLoader as DataTable } from '../data-table';
 
 describe('DataTable', () => {
   const onSelect = jest.fn();

--- a/src/components/data-list.jsx
+++ b/src/components/data-list.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import withDataLoader from './data-loader';
 
-const DataList = ({ data, getIdKey, dataRenderer }) => (
+export const DataList = ({ data, getIdKey, dataRenderer }) => (
   <>
     {data.map((content) => (
       <section key={getIdKey(content)}>{dataRenderer(content)}</section>
@@ -29,4 +29,4 @@ DataList.defaultProps = {
   getIdKey: ({ id }) => id,
 };
 
-export default withDataLoader(DataList);
+export const DataListWithLoader = withDataLoader(DataList);

--- a/src/components/data-loader.jsx
+++ b/src/components/data-loader.jsx
@@ -43,7 +43,7 @@ const withDataLoader = (BaseComponent) => {
     };
 
     const observer = useMemo(() => {
-      if (!ioSupport || clickToLoad) {
+      if (!ioSupport || clickToLoad || typeof onLoadMoreItems !== 'function') {
         return;
       }
       // eslint-disable-next-line consistent-return
@@ -51,7 +51,7 @@ const withDataLoader = (BaseComponent) => {
         // use it inside an other function, otherwise will use the first version
         observerCallbackRef.current(...entries)
       );
-    }, [clickToLoad]);
+    }, [clickToLoad, onLoadMoreItems]);
 
     // eslint-disable-next-line consistent-return
     useEffect(() => {
@@ -81,26 +81,30 @@ const withDataLoader = (BaseComponent) => {
       );
     }
 
-    return (
+    return typeof onLoadMoreItems === 'function' ? (
       <>
         <BaseComponent {...props} />
         <div className="data-loader__loading" ref={sentinelRef}>
           {hasMoreData && sentinelContent}
         </div>
       </>
+    ) : (
+      <BaseComponent {...props} />
     );
   };
 
   Wrapper.propTypes = {
     /**
      * Callback to request more items if user scrolled to the bottom of the scroll-container or if
-     * the scroll-container isn't scrollable yet because not enough items have been loaded yet.
+     * the scroll-container isn't scrollable yet because not enough items have been loaded yet. If
+     * not provided this component will simply pass the data prop to the BaseComponent to be rendered
+     * without observing scroll or triggering more data loading.
      */
-    onLoadMoreItems: PropTypes.func.isRequired,
+    onLoadMoreItems: PropTypes.func,
     /**
      * A boolean to indicate that the parent has more items to provide.
      */
-    hasMoreData: PropTypes.bool.isRequired,
+    hasMoreData: PropTypes.bool,
     /**
      * A custom loader component
      */
@@ -116,6 +120,8 @@ const withDataLoader = (BaseComponent) => {
   };
 
   Wrapper.defaultProps = {
+    onLoadMoreItems: null,
+    hasMoreData: false,
     loaderComponent: <Loader />,
     clickToLoad: false,
   };

--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useCallback,
   ReactNode,
+  FC,
 } from 'react';
 
 import Button from './button';
@@ -42,9 +43,7 @@ type WrapperProps = {
   clickToLoad?: boolean;
 };
 
-const withDataLoader = (
-  BaseComponent: FC<{ data: unknown[] }>
-) => {
+const withDataLoader = (BaseComponent: FC<{ data: unknown[] }>) => {
   const Wrapper: FC<WrapperProps> = ({
     onLoadMoreItems,
     hasMoreData,

--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -21,10 +21,12 @@ type WrapperProps = {
    * not provided this component will simply pass the data prop to the BaseComponent to be rendered
    * without observing scroll or triggering more data loading.
    */
+  // eslint-disable-next-line react/require-default-props
   onLoadMoreItems?: () => void;
   /**
    * A boolean to indicate that the parent has more items to provide.
    */
+  // eslint-disable-next-line react/require-default-props
   hasMoreData?: boolean;
   /**
    * A custom loader component

--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -43,7 +43,7 @@ type WrapperProps = {
 };
 
 const withDataLoader = (
-  BaseComponent: (props: { data: unknown[] }) => JSX.Element
+  BaseComponent: FC<{ data: unknown[] }>
 ) => {
   const Wrapper = ({
     onLoadMoreItems,

--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -21,17 +21,16 @@ type WrapperProps = {
    * not provided this component will simply pass the data prop to the BaseComponent to be rendered
    * without observing scroll or triggering more data loading.
    */
-  // eslint-disable-next-line react/require-default-props
-  onLoadMoreItems?: () => void;
+  onLoadMoreItems: () => void;
   /**
    * A boolean to indicate that the parent has more items to provide.
    */
-  // eslint-disable-next-line react/require-default-props
-  hasMoreData?: boolean;
+  hasMoreData: boolean;
   /**
    * A custom loader component
    */
-  loaderComponent: ReactNode;
+  // eslint-disable-next-line react/require-default-props
+  loaderComponent?: ReactNode;
   /**
    * Data that is being represented in the wrapped component
    */
@@ -39,20 +38,21 @@ type WrapperProps = {
   /**
    * Use a button to load more data instead of having infinite scrolling
    */
-  clickToLoad: boolean;
+  // eslint-disable-next-line react/require-default-props
+  clickToLoad?: boolean;
 };
 
 const withDataLoader = (
-  BaseComponent: (props: WrapperProps) => JSX.Element
+  BaseComponent: (props: { data: unknown[] }) => JSX.Element
 ) => {
-  const Wrapper = (props: WrapperProps) => {
-    const {
-      onLoadMoreItems,
-      hasMoreData = false,
-      loaderComponent = <Loader />,
-      data,
-      clickToLoad = false,
-    } = props;
+  const Wrapper = ({
+    onLoadMoreItems,
+    hasMoreData,
+    loaderComponent = <Loader />,
+    data,
+    clickToLoad = false,
+    ...restProps
+  }: WrapperProps) => {
     // store this prop in a ref to not trigger re-creation of observer if the user
     // of this component forgot to memoize 'onLoadMoreItems' function.
     const onLoadMoreItemsRef = useRef(onLoadMoreItems);
@@ -84,7 +84,7 @@ const withDataLoader = (
     };
 
     const observer = useMemo(() => {
-      if (!ioSupport || clickToLoad || typeof onLoadMoreItems !== 'function') {
+      if (!ioSupport || clickToLoad) {
         return;
       }
       // eslint-disable-next-line consistent-return
@@ -94,7 +94,7 @@ const withDataLoader = (
           observerCallbackRef.current(entry);
         }
       });
-    }, [clickToLoad, onLoadMoreItems]);
+    }, [clickToLoad]);
 
     // eslint-disable-next-line consistent-return
     useEffect(() => {
@@ -124,15 +124,13 @@ const withDataLoader = (
       );
     }
 
-    return typeof onLoadMoreItems === 'function' ? (
+    return (
       <>
-        <BaseComponent {...props} />
+        <BaseComponent data={data} {...restProps} />
         <div className="data-loader__loading" ref={sentinelRef}>
           {hasMoreData && sentinelContent}
         </div>
       </>
-    ) : (
-      <BaseComponent {...props} />
     );
   };
 

--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -45,7 +45,7 @@ type WrapperProps = {
 const withDataLoader = (
   BaseComponent: FC<{ data: unknown[] }>
 ) => {
-  const Wrapper = ({
+  const Wrapper: FC<WrapperProps> = ({
     onLoadMoreItems,
     hasMoreData,
     loaderComponent = <Loader />,

--- a/src/components/data-table.jsx
+++ b/src/components/data-table.jsx
@@ -167,7 +167,7 @@ DataTableBody.defaultProps = {
   getIdKey: ({ id }) => id,
 };
 
-const DataTable = ({
+export const DataTable = ({
   data,
   columns,
   onSelect,
@@ -226,4 +226,4 @@ DataTable.defaultProps = {
   propsForTable: null,
 };
 
-export default withDataLoader(DataTable);
+export const DataTableWithLoader = withDataLoader(DataTable);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,9 +8,10 @@ export { default as ButtonModal } from './button-modal';
 export { default as Card } from './card';
 export { default as Chip } from './chip';
 export { default as CodeBlock } from './code-block';
-export { default as DataList } from './data-list';
+export { DataList, DataListWithLoader } from './data-list';
 export {
-  default as DataTable,
+  DataTable,
+  DataTableWithLoader,
   DENSITY_COMPACT,
   DENSITY_NORMAL,
 } from './data-table';

--- a/src/decorators/DataDecorator.jsx
+++ b/src/decorators/DataDecorator.jsx
@@ -3,53 +3,53 @@ import PropTypes from 'prop-types';
 
 import { getLipsumObjectArray } from '../mock-data/lipsum';
 
-const DataDecorator = ({ children, ...props }) => {
+const totalNumberDataPoints = 50;
+const getIdKey = ({ id }) => id;
+const columns = [
+  {
+    label: 'Column 1',
+    name: 'content1',
+    render: (row) => row.content1,
+    sortable: true,
+    sorted: 'ascend',
+  },
+  {
+    label: 'Column 2',
+    name: 'content2',
+    render: (row) => row.content2,
+  },
+  {
+    label: 'Column 3',
+    name: 'content3',
+    render: (row) => row.content3,
+    sortable: true,
+  },
+  {
+    label: 'Column 4',
+    name: 'content4',
+    render: (row) => row.content4,
+    width: '40vw',
+    sortable: true,
+  },
+  {
+    label: 'Column 5',
+    name: 'content5',
+    render: (row) => row.content5,
+  },
+];
+
+function generateData(numberElements) {
+  return getLipsumObjectArray({
+    keys: columns.map((column) => column.name),
+    numberElements,
+  });
+}
+
+export const DataLoaderDecorator = ({ children, ...props }) => {
   let loadingData = false;
-  const getIdKey = ({ id }) => id;
   const numberDataPointsPerRequest = 6;
-  const totalNumberDataPoints = 50;
   const sleepDuration = 0.75;
   const numberInitialDataPoints = 1;
-
-  const columns = [
-    {
-      label: 'Column 1',
-      name: 'content1',
-      render: (row) => row.content1,
-      sortable: true,
-      sorted: 'ascend',
-    },
-    {
-      label: 'Column 2',
-      name: 'content2',
-      render: (row) => row.content2,
-    },
-    {
-      label: 'Column 3',
-      name: 'content3',
-      render: (row) => row.content3,
-      sortable: true,
-    },
-    {
-      label: 'Column 4',
-      name: 'content4',
-      render: (row) => row.content4,
-      width: '40vw',
-      sortable: true,
-    },
-    {
-      label: 'Column 5',
-      name: 'content5',
-      render: (row) => row.content5,
-    },
-  ];
-
-  function generateData(numberElements) {
-    return getLipsumObjectArray({
-      keys: columns.map((column) => column.name),
-      numberElements,
-    });
-  }
 
   const [data, setData] = useState(
     numberInitialDataPoints > 0 ? generateData(numberInitialDataPoints) : []
@@ -85,8 +85,19 @@ const DataDecorator = ({ children, ...props }) => {
   );
 };
 
-DataDecorator.propTypes = {
+DataLoaderDecorator.propTypes = {
   children: PropTypes.func.isRequired,
 };
 
-export default DataDecorator;
+export const DataDecorator = ({ children, ...props }) => (
+  <div {...props}>
+    {children({
+      data: generateData(totalNumberDataPoints),
+      getIdKey,
+      columns,
+    })}
+  </div>
+);
+DataDecorator.propTypes = {
+  children: PropTypes.func.isRequired,
+};

--- a/stories/DataList.stories.jsx
+++ b/stories/DataList.stories.jsx
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions';
 
-import { DataList, Card } from '../src/components';
+import { DataListWithLoader, Card } from '../src/components';
 import DataDecorator from '../src/decorators/DataDecorator';
 
 export default {
@@ -14,20 +14,18 @@ export default {
   decorators: [(story) => <DataDecorator>{story}</DataDecorator>],
 };
 
-export const dataList = (_, props) => {
-  return (
-    <DataList
-      {...props}
-      onSelect={action('onSelect')}
-      onHeaderClick={action('onHeaderClick')}
-      dataRenderer={(content) => <>{Object.values(content)}</>}
-      selectable
-    />
-  );
-};
+export const dataList = (_, props) => (
+  <DataListWithLoader
+    {...props}
+    onSelect={action('onSelect')}
+    onHeaderClick={action('onHeaderClick')}
+    dataRenderer={(content) => <>{Object.values(content)}</>}
+    selectable
+  />
+);
 
 export const dataListWithCards = (_, props) => (
-  <DataList
+  <DataListWithLoader
     {...props}
     onHeaderClick={action('onHeaderClick')}
     dataRenderer={(content) => (
@@ -37,5 +35,5 @@ export const dataListWithCards = (_, props) => (
   />
 );
 
-dataList.propTypes = DataList.propTypes;
-dataListWithCards.propTypes = DataList.propTypes;
+dataList.propTypes = DataListWithLoader.propTypes;
+dataListWithCards.propTypes = DataListWithLoader.propTypes;

--- a/stories/DataList.stories.jsx
+++ b/stories/DataList.stories.jsx
@@ -1,7 +1,10 @@
 import { action } from '@storybook/addon-actions';
 
-import { DataListWithLoader, Card } from '../src/components';
-import DataDecorator from '../src/decorators/DataDecorator';
+import { DataList, DataListWithLoader, Card } from '../src/components';
+import {
+  DataDecorator,
+  DataLoaderDecorator,
+} from '../src/decorators/DataDecorator';
 
 export default {
   title: 'Data/Data List',
@@ -11,10 +14,21 @@ export default {
       function: '',
     },
   },
-  decorators: [(story) => <DataDecorator>{story}</DataDecorator>],
+  decorators: [(story) => <DataLoaderDecorator>{story}</DataLoaderDecorator>],
 };
 
 export const dataList = (_, props) => (
+  <DataList
+    {...props}
+    onSelect={action('onSelect')}
+    onHeaderClick={action('onHeaderClick')}
+    dataRenderer={(content) => <>{Object.values(content)}</>}
+    selectable
+  />
+);
+dataList.decorators = [(story) => <DataDecorator>{story}</DataDecorator>];
+
+export const dataListWithLoader = (_, props) => (
   <DataListWithLoader
     {...props}
     onSelect={action('onSelect')}
@@ -24,7 +38,7 @@ export const dataList = (_, props) => (
   />
 );
 
-export const dataListWithCards = (_, props) => (
+export const dataListWithLoaderAndCards = (_, props) => (
   <DataListWithLoader
     {...props}
     onHeaderClick={action('onHeaderClick')}
@@ -36,4 +50,4 @@ export const dataListWithCards = (_, props) => (
 );
 
 dataList.propTypes = DataListWithLoader.propTypes;
-dataListWithCards.propTypes = DataListWithLoader.propTypes;
+dataListWithLoaderAndCards.propTypes = DataListWithLoader.propTypes;

--- a/stories/DataTable.stories.jsx
+++ b/stories/DataTable.stories.jsx
@@ -1,10 +1,14 @@
 import { action } from '@storybook/addon-actions';
 
 import {
-  DataTableWithLoader as DataTableComponent,
+  DataTable,
+  DataTableWithLoader,
   DENSITY_COMPACT,
 } from '../src/components';
-import DataDecorator from '../src/decorators/DataDecorator';
+import {
+  DataDecorator,
+  DataLoaderDecorator,
+} from '../src/decorators/DataDecorator';
 
 export default {
   title: 'Data/Data Table',
@@ -14,11 +18,21 @@ export default {
       function: '',
     },
   },
-  decorators: [(story) => <DataDecorator>{story}</DataDecorator>],
+  decorators: [(story) => <DataLoaderDecorator>{story}</DataLoaderDecorator>],
 };
 
 export const dataTable = (_, props) => (
-  <DataTableComponent
+  <DataTable
+    {...props}
+    onSelect={action('onSelect')}
+    onHeaderClick={action('onHeaderClick')}
+    selectable
+  />
+);
+dataTable.decorators = [(story) => <DataDecorator>{story}</DataDecorator>];
+
+export const dataTableWithLoader = (_, props) => (
+  <DataTableWithLoader
     {...props}
     onSelect={action('onSelect')}
     onHeaderClick={action('onHeaderClick')}
@@ -26,8 +40,8 @@ export const dataTable = (_, props) => (
   />
 );
 
-export const dataTableClickToLoad = (_, props) => (
-  <DataTableComponent
+export const dataTableWithLoaderClickToLoad = (_, props) => (
+  <DataTableWithLoader
     {...props}
     clickToLoad
     onSelect={action('onSelect')}
@@ -36,8 +50,8 @@ export const dataTableClickToLoad = (_, props) => (
   />
 );
 
-export const dataTableCompact = (_, props) => (
-  <DataTableComponent
+export const dataTableWithLoaderCompact = (_, props) => (
+  <DataTableWithLoader
     {...props}
     onSelect={action('onSelect')}
     onHeaderClick={action('onHeaderClick')}
@@ -46,8 +60,8 @@ export const dataTableCompact = (_, props) => (
   />
 );
 
-export const fixedTable = (_, props) => (
-  <DataTableComponent
+export const fixedTableWithLoader = (_, props) => (
+  <DataTableWithLoader
     {...props}
     onSelect={action('onSelect')}
     selectable
@@ -55,4 +69,4 @@ export const fixedTable = (_, props) => (
   />
 );
 
-dataTableCompact.propTypes = DataTableComponent.propTypes;
+dataTableWithLoaderCompact.propTypes = DataTableWithLoader.propTypes;

--- a/stories/DataTable.stories.jsx
+++ b/stories/DataTable.stories.jsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 
 import {
-  DataTable as DataTableComponent,
+  DataTableWithLoader as DataTableComponent,
   DENSITY_COMPACT,
 } from '../src/components';
 import DataDecorator from '../src/decorators/DataDecorator';


### PR DESCRIPTION
## Purpose
In the UniProt website there are a few places where we use DataList, DataTable without needing the data-loading functionality (eg BlastResultTable). Doing this however throws some warnings about not passing the required onLoadMoreItems prop. This PR makes these props optional.

## Approach
Make onLoadMoreItems and hasMoreData optional and don't use the interaction observer if not needed.

## Testing
No tests updated.

## Stories
None updated.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiable through knobs?