### PR TITLE
Intersection observer mocking

### DIFF
--- a/src/components/__tests__/__snapshots__/data-table.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/data-table.spec.jsx.snap
@@ -295,13 +295,15 @@ exports[`DataTable should render autoload 1`] = `
   <div
     class="data-loader__loading"
   >
-    <button
-      class="button secondary"
-      data-testid="click-to-load-more"
-      type="button"
+    <div
+      class="loader-container"
     >
-      Load more data
-    </button>
+      <test-file-stub
+        classname="loader"
+        height="100"
+        width="100"
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/__tests__/data-table.spec.jsx
+++ b/src/components/__tests__/data-table.spec.jsx
@@ -53,6 +53,14 @@ describe('DataTable', () => {
 
   beforeEach(() => {
     onLoadMoreItems = jest.fn();
+    window.IntersectionObserver = jest.fn(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+    }));
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
   });
 
   test('should render autoload', () => {
@@ -93,5 +101,11 @@ describe('DataTable', () => {
     const header = screen.getByText(/Column 1/);
     fireEvent.click(header);
     expect(onHeaderClick).toHaveBeenCalled();
+  });
+
+  test('should show click-to-load if no IntersectionObserver support', () => {
+    delete window.IntersectionObserver;
+    renderTable({ clickToLoad: false });
+    expect(screen.getByTestId('click-to-load-more')).toBeTruthy();
   });
 });

--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -13,8 +13,6 @@ import Loader from './loader';
 
 import '../styles/components/data-loader.scss';
 
-const ioSupport = 'IntersectionObserver' in window;
-
 type WrapperProps = {
   /**
    * Callback to request more items if user scrolled to the bottom of the scroll-container or if
@@ -82,6 +80,8 @@ const withDataLoader = (BaseComponent: FC<{ data: unknown[] }>) => {
       handleAskForMoreData();
     };
 
+    const { current: ioSupport } = useRef('IntersectionObserver' in window);
+
     const observer = useMemo(() => {
       if (!ioSupport || clickToLoad) {
         return;
@@ -93,7 +93,7 @@ const withDataLoader = (BaseComponent: FC<{ data: unknown[] }>) => {
           observerCallbackRef.current(entry);
         }
       });
-    }, [clickToLoad]);
+    }, [clickToLoad, ioSupport]);
 
     // eslint-disable-next-line consistent-return
     useEffect(() => {

--- a/src/components/data-loader.tsx
+++ b/src/components/data-loader.tsx
@@ -80,10 +80,8 @@ const withDataLoader = (BaseComponent: FC<{ data: unknown[] }>) => {
       handleAskForMoreData();
     };
 
-    const { current: ioSupport } = useRef('IntersectionObserver' in window);
-
     const observer = useMemo(() => {
-      if (!ioSupport || clickToLoad) {
+      if (!('IntersectionObserver' in window) || clickToLoad) {
         return;
       }
       // eslint-disable-next-line consistent-return
@@ -93,7 +91,7 @@ const withDataLoader = (BaseComponent: FC<{ data: unknown[] }>) => {
           observerCallbackRef.current(entry);
         }
       });
-    }, [clickToLoad, ioSupport]);
+    }, [clickToLoad]);
 
     // eslint-disable-next-line consistent-return
     useEffect(() => {
@@ -111,7 +109,7 @@ const withDataLoader = (BaseComponent: FC<{ data: unknown[] }>) => {
     }, [length]);
 
     let sentinelContent = loaderComponent;
-    if ((!ioSupport || clickToLoad) && !loading) {
+    if ((!('IntersectionObserver' in window) || clickToLoad) && !loading) {
       sentinelContent = (
         <Button
           variant="secondary"

--- a/stories/DecoratedListItem.stories.tsx
+++ b/stories/DecoratedListItem.stories.tsx
@@ -32,7 +32,7 @@ const data = [
 export const decoratedListItem = () => (
   <div className="uniprot-grid">
     {data.map((i) => (
-      <div className="uniprot-grid-cell--span-3">
+      <div key={i.title} className="uniprot-grid-cell--span-3">
         <DecoratedListItem compact altStyle>
           <h3>{i.title}</h3>
         </DecoratedListItem>


### PR DESCRIPTION
## Purpose
Test coverage decreased in last PR so needed to bring it back up. Noticed in the cov report the ioSupport wasn't tested so this PR tests this.

## Approach
Mocking IntersectionObserver. Had to push `ioSupport` test inside of `withDataLoader`.

## Testing
`should show click-to-load if no IntersectionObserver support`

## Stories
N/A

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
 also: add key in story DecoratedListItem
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
