### PR TITLE
add a visual cue that a column is sortable even though it is not sorted

### DIFF
--- a/src/components/__tests__/__snapshots__/data-table.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/data-table.spec.tsx.snap
@@ -13,15 +13,17 @@ exports[`DataTable should render autoload 1`] = `
            
         </th>
         <th
-          class="data-table__header-cell--ascend"
+          class="data-table__header-cell--sortable data-table__header-cell--ascend"
         >
           Column 1
         </th>
-        <th>
+        <th
+          class=""
+        >
           Column 2
         </th>
         <th
-          class="data-table__header-cell--ascend"
+          class="data-table__header-cell--sortable"
         >
           <h1>
             Column 3
@@ -234,15 +236,17 @@ exports[`DataTable should render click-to-load 1`] = `
            
         </th>
         <th
-          class="data-table__header-cell--ascend"
+          class="data-table__header-cell--sortable data-table__header-cell--ascend"
         >
           Column 1
         </th>
-        <th>
+        <th
+          class=""
+        >
           Column 2
         </th>
         <th
-          class="data-table__header-cell--ascend"
+          class="data-table__header-cell--sortable"
         >
           <h1>
             Column 3

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -68,11 +68,11 @@ function DataTableHead<T>({
         {columns.map(({ sorted, name, label, sortable, width }) => (
           <th
             key={name}
-            className={
-              sorted || sortable
-                ? `${BLOCK}__header-cell--${sorted || 'ascend'}`
-                : undefined
-            }
+            className={cn({
+              [`${BLOCK}__header-cell--sortable`]: sortable,
+              [`${BLOCK}__header-cell--${sorted || 'ascend'}`]:
+                sortable && sorted,
+            })}
             onClick={sortable ? () => onHeaderClick?.(name) : undefined}
             style={width ? { width } : undefined}
           >

--- a/src/styles/components/data-table.scss
+++ b/src/styles/components/data-table.scss
@@ -35,9 +35,10 @@
 
   &__header-cell {
     &--sortable {
+      cursor: pointer;
+
       &::after {
         content: '▲';
-        cursor: pointer;
         display: inline-block;
         font-size: 0.6em;
         margin: 0 0.8em;

--- a/src/styles/components/data-table.scss
+++ b/src/styles/components/data-table.scss
@@ -34,20 +34,31 @@
   }
 
   &__header-cell {
-    &--ascend,
-    &--descend {
+    &--sortable {
       &::after {
         content: '▲';
         cursor: pointer;
         display: inline-block;
         font-size: 0.6em;
         margin: 0 0.8em;
+        opacity: 0.7;
         transition: transform ease-out 0.5s;
         transform: rotateX(0);
 
         @media (prefers-reduced-motion: reduce) {
           transition-duration: 0s;
         }
+      }
+
+      &:hover::after {
+        opacity: 1;
+      }
+    }
+
+    &--ascend,
+    &--descend {
+      &::after {
+        opacity: 1;
       }
     }
 


### PR DESCRIPTION
## Purpose
Add a third state to a column header where it can be visually marked as sortable even though it is not sorted.

## Approach
Visual change, opacity 0.7 on a sortable column

## Testing
Updated snapshots, checked story

## Stories
data table story

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
