### PR TITLE
make Chip component use the Button component

### DIFF
--- a/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Chip component should render 1`] = `
 <DocumentFragment>
   <button
-    class="chip"
+    class="button primary disabled chip"
     disabled=""
     type="button"
   >

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -9,7 +9,7 @@ type PossibleElements =
   | FunctionComponent
   | ComponentClass;
 
-type ButtonProps = {
+export type ButtonProps = {
   /**
    * The element to use as a button
    */

--- a/src/components/chip.tsx
+++ b/src/components/chip.tsx
@@ -4,9 +4,10 @@ import {
   useRef,
   ReactNode,
   MouseEvent as ReactMouseEvent,
-  HTMLAttributes,
 } from 'react';
 import cn from 'classnames';
+
+import { Button, ButtonProps } from './button';
 
 import RemoveIcon from '../svg/times.svg';
 
@@ -26,7 +27,7 @@ type ChipProps = {
    */
   disabled?: boolean;
   /**
-   * Additional CSS classnames to apply (eg secondary, tertiary)
+   * Additional CSS classnames to apply
    */
   className?: string;
   /**
@@ -43,10 +44,10 @@ type ChipProps = {
   onClick?: () => void;
 };
 
-export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
+export const Chip: FC<ChipProps & ButtonProps> = ({
   children,
   onRemove,
-  className = '',
+  className,
   disabled,
   compact = false,
   title,
@@ -65,8 +66,7 @@ export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
   );
 
   return (
-    <button
-      type="button"
+    <Button
       className={cn(
         'chip',
         { 'chip--disabled': disabled, 'chip--compact': compact },
@@ -74,14 +74,20 @@ export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
       )}
       title={title}
       onClick={onClick}
-      disabled={typeof disabled === 'boolean' ? disabled : !onClick}
+      disabled={
+        typeof disabled === 'boolean' ? disabled : !(onClick || onRemove)
+      }
       {...props}
     >
       {children}
       {onRemove && !disabled && (
-        <RemoveIcon data-testid="remove-icon" onClick={handleRemove} />
+        <RemoveIcon
+          className="chip__remove-icon"
+          data-testid="remove-icon"
+          onClick={handleRemove}
+        />
       )}
-    </button>
+    </Button>
   );
 };
 

--- a/src/styles/components/chip.scss
+++ b/src/styles/components/chip.scss
@@ -19,7 +19,7 @@
   cursor: default;
   white-space: nowrap;
 
-  svg {
+  svg.chip__remove-icon {
     margin-top: -0.2rem;
     margin-left: 0.2rem;
     margin-right: 0;

--- a/stories/Chips.stories.tsx
+++ b/stories/Chips.stories.tsx
@@ -54,7 +54,7 @@ export const withClick = () => (
     <Chip title="this is a primary chip" onClick={action('click on primary')}>
       Primary
     </Chip>
-    <Chip className="secondary" onClick={action('click on secondary')}>
+    <Chip variant="secondary" onClick={action('click on secondary')}>
       Secondary
     </Chip>
   </>
@@ -63,7 +63,7 @@ export const withClick = () => (
 export const removable = () => (
   <>
     <Chip onRemove={action('Remove chip')}>Primary</Chip>
-    <Chip onRemove={action('Remove chip')} className="secondary">
+    <Chip onRemove={action('Remove chip')} variant="secondary">
       Secondary
     </Chip>
   </>


### PR DESCRIPTION
## Purpose
Have the Chip component be a specific wrapper of the Button component

## Approach
Make the Chip component use the Button component

## Testing
Updated snapshots and stories

## Stories
Chip

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
