### PR TITLE
reduce markup complexity for cards

### DIFF
--- a/src/components/__tests__/__snapshots__/card.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/card.spec.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`Card component should render 1`] = `
 <DocumentFragment>
-  <div
+  <section
     class="card"
   >
-    <section>
+    <div>
       <div
         class="card__header"
       >
@@ -22,17 +22,17 @@ exports[`Card component should render 1`] = `
           Some content
         </span>
       </div>
-    </section>
-  </div>
+    </div>
+  </section>
 </DocumentFragment>
 `;
 
 exports[`Card component should render card with links 1`] = `
 <DocumentFragment>
-  <div
+  <section
     class="card"
   >
-    <section>
+    <div>
       <div
         class="card__header"
       >
@@ -54,31 +54,28 @@ exports[`Card component should render card with links 1`] = `
           Some content
         </span>
       </div>
-    </section>
-    <section
+    </div>
+    <div
       class="card__actions"
     >
-      <span
+      <a
         class="card__link"
+        href="/example.com"
         style="border-bottom: 0.125rem solid red;"
       >
-        <a
-          href="/example.com"
-        >
-          link
-        </a>
-      </span>
-    </section>
-  </div>
+        link
+      </a>
+    </div>
+  </section>
 </DocumentFragment>
 `;
 
 exports[`Card component should render card with onclick 1`] = `
 <DocumentFragment>
-  <div
+  <section
     class="card"
   >
-    <section
+    <div
       class="card--has-hover"
       role="button"
       tabindex="0"
@@ -104,17 +101,17 @@ exports[`Card component should render card with onclick 1`] = `
           Some content
         </span>
       </div>
-    </section>
-  </div>
+    </div>
+  </section>
 </DocumentFragment>
 `;
 
 exports[`Card component should render card with subtitle 1`] = `
 <DocumentFragment>
-  <div
+  <section
     class="card"
   >
-    <section>
+    <div>
       <div
         class="card__header"
       >
@@ -136,7 +133,7 @@ exports[`Card component should render card with subtitle 1`] = `
           Some content
         </span>
       </div>
-    </section>
-  </div>
+    </div>
+  </section>
 </DocumentFragment>
 `;

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, FC, ReactNode, HTMLAttributes } from 'react';
+import { forwardRef, FC, ReactNode, HTMLAttributes, Fragment } from 'react';
 import { NavLink, LinkProps } from 'react-router-dom';
 import cn from 'classnames';
 
@@ -8,25 +8,17 @@ type CardLinkProps = {
   name: string;
   link: LinkProps['to'];
   color?: string;
-  includeSeparator?: boolean;
 };
 
-const CardLink: FC<CardLinkProps> = ({
-  name,
-  link,
-  color,
-  includeSeparator,
-}) => (
-  <span
-    className={cn('card__link', {
-      'card__link--separator': includeSeparator,
-    })}
-    style={color ? { borderBottom: `0.125rem solid ${color}` } : {}}
+const CardLink: FC<CardLinkProps> = ({ name, link, color }) => (
+  <NavLink
+    to={link}
+    className="card__link"
+    activeClassName="card__link--active"
+    style={color ? { borderBottom: `0.125rem solid ${color}` } : undefined}
   >
-    <NavLink to={link} activeClassName="card__link--active">
-      {name}
-    </NavLink>
-  </span>
+    {name}
+  </NavLink>
 );
 
 type Props = {
@@ -41,14 +33,14 @@ type Props = {
   /**
    * Links to be displayed at the bottom of the card
    */
-  links?: Array<Omit<CardLinkProps, 'includeSeparator'>>;
+  links?: Array<CardLinkProps>;
   /**
    * Should the card styling show it as active or not
    */
   active?: boolean;
 };
 
-const Card = forwardRef<HTMLDivElement, Props & HTMLAttributes<HTMLDivElement>>(
+const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
   (
     {
       title,
@@ -73,12 +65,12 @@ const Card = forwardRef<HTMLDivElement, Props & HTMLAttributes<HTMLDivElement>>(
         }
       : {};
     return (
-      <div
+      <section
         className={cn(className, 'card', { 'card--active': active })}
         ref={ref}
         {...props}
       >
-        <section {...containerAttributes}>
+        <div {...containerAttributes}>
           {title && (
             <div className="card__header">
               <h2 className="card__title">{title}</h2>
@@ -86,15 +78,18 @@ const Card = forwardRef<HTMLDivElement, Props & HTMLAttributes<HTMLDivElement>>(
             </div>
           )}
           <div className="card__content">{children}</div>
-        </section>
+        </div>
         {links?.length ? (
-          <section className="card__actions">
-            {links.map((l, i) => (
-              <CardLink key={l.name} {...l} includeSeparator={i > 0} />
+          <div className="card__actions">
+            {links.map((link, index) => (
+              <Fragment key={link.name}>
+                {index > 0 && ' · '}
+                <CardLink {...link} />
+              </Fragment>
             ))}
-          </section>
+          </div>
         ) : undefined}
-      </div>
+      </section>
     );
   }
 );

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, FC, ReactNode, HTMLAttributes, Fragment } from 'react';
+import { forwardRef, FC, ReactNode, HTMLAttributes } from 'react';
 import { NavLink, LinkProps } from 'react-router-dom';
 import cn from 'classnames';
 
@@ -81,11 +81,8 @@ const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
         </div>
         {links?.length ? (
           <div className="card__actions">
-            {links.map((link, index) => (
-              <Fragment key={link.name}>
-                {index > 0 && ' · '}
-                <CardLink {...link} />
-              </Fragment>
+            {links.map((link) => (
+              <CardLink key={link.name} {...link} />
             ))}
           </div>
         ) : undefined}

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -20,6 +20,7 @@ $card-link-padding: 0.5rem;
 
   &__header {
     padding-left: $global-padding;
+
     &__checkbox {
       input[type='checkbox'] {
         margin: 0 0.75rem 0.5rem 0;
@@ -31,23 +32,28 @@ $card-link-padding: 0.5rem;
   &__content {
     padding: $global-padding;
   }
+
   &__title {
     margin: 0;
     margin-right: $global-margin;
   }
+
   &__header {
     display: flex;
     align-items: baseline;
     border-bottom: 0.125rem solid;
     border-color: $colour-platinum;
   }
+
   &__actions {
     display: flex;
+    align-items: center;
     flex-wrap: nowrap;
     overflow-x: auto;
     padding: 0;
     background-color: $colour-selected;
   }
+
   &--active {
     background-color: scale-color($color: $colour-platinum, $lightness: 20%);
   }
@@ -59,17 +65,13 @@ $card-link-padding: 0.5rem;
   font-weight: 600;
   white-space: nowrap;
   background-color: $colour-gainsborough;
+
   &:hover {
     transition: 0.5s background-color ease;
     background-color: $colour-hover;
   }
+
   &--active {
     background-color: scale-color($color: $colour-platinum, $lightness: 20%);
   }
-}
-
-.card__link--separator::before {
-  content: ' · ';
-  margin-left: -$card-link-padding;
-  margin-right: $card-link-padding;
 }

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -71,6 +71,12 @@ $card-link-padding: 0.5rem;
     background-color: $colour-hover;
   }
 
+  &:not(:first-child)::before {
+    content: ' · ';
+    margin-left: -$card-link-padding;
+    margin-right: $card-link-padding;
+  }
+
   &--active {
     background-color: scale-color($color: $colour-platinum, $lightness: 20%);
   }


### PR DESCRIPTION
## Purpose
Reduce markup complexity of the Card component, and use only one `section` element for each card

## Approach
Change markup

## Testing
Updated snapshots

## Stories
Card

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
