### PR TITLE
Render ReactNode in InfoList entry title. Allow passing keys to accommodate this change.

### DIFF
--- a/src/components/__tests__/__snapshots__/info-list.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/info-list.spec.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`InfoList component should not render items that are undefined 1`] = `
+<DocumentFragment>
+  <ul
+    class="info-list info-list--columns"
+  />
+</DocumentFragment>
+`;
+
 exports[`InfoList component should render 1`] = `
 <DocumentFragment>
   <ul
@@ -106,7 +114,40 @@ exports[`InfoList component should render compact 1`] = `
 </DocumentFragment>
 `;
 
-exports[`InfoList component should render without in 2 columns 1`] = `
+exports[`InfoList component should render title that is a React Node 1`] = `
+<DocumentFragment>
+  <ul
+    class="info-list"
+  >
+    <li>
+      <div
+        class="decorated-list-item"
+      >
+        <div
+          class="decorated-list-item__title"
+        >
+          <h5
+            class="bold"
+          >
+            <div>
+              Item 1
+            </div>
+          </h5>
+        </div>
+        <div
+          class="decorated-list-item__content"
+        >
+          <div>
+            Some content
+          </div>
+        </div>
+      </div>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
+exports[`InfoList component should render with titles in 2 columns 1`] = `
 <DocumentFragment>
   <ul
     class="info-list info-list--columns"

--- a/src/components/__tests__/info-list.spec.tsx
+++ b/src/components/__tests__/info-list.spec.tsx
@@ -3,63 +3,51 @@ import { render } from '@testing-library/react';
 import InfoList from '../info-list';
 
 describe('InfoList component', () => {
-  test('should render', () => {
-    const infoData = [
-      {
-        title: 'Item 1',
-        content: <div>Some content</div>,
-      },
-      {
-        title: 'Another item',
-        content: <div>Some more content</div>,
-      },
-    ];
+  const infoData = [
+    {
+      title: 'Item 1',
+      content: <div>Some content</div>,
+    },
+    {
+      title: 'Another item',
+      content: <div>Some more content</div>,
+    },
+  ];
+  it('should render', () => {
     const { asFragment } = render(<InfoList infoData={infoData} />);
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('should render compact', () => {
-    const infoData = [
-      {
-        title: 'Item 1',
-        content: <div>Some content</div>,
-      },
-      {
-        title: 'Another item',
-        content: <div>Some more content</div>,
-      },
-    ];
+  it('should render compact', () => {
     const { asFragment } = render(<InfoList infoData={infoData} isCompact />);
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('should render without titles', () => {
-    const infoData = [
-      {
-        title: 'Item 1',
-        content: <div>Some content</div>,
-      },
-      {
-        title: 'Another item',
-        content: <div>Some more content</div>,
-      },
-    ];
+  it('should render without titles', () => {
     const { asFragment } = render(<InfoList infoData={infoData} noTitles />);
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('should render without in 2 columns', () => {
-    const infoData = [
-      {
-        title: 'Item 1',
-        content: <div>Some content</div>,
-      },
-      {
-        title: 'Another item',
-        content: <div>Some more content</div>,
-      },
-    ];
+  it('should render with titles in 2 columns', () => {
     const { asFragment } = render(<InfoList infoData={infoData} columns />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should not render items that are undefined', () => {
+    const { asFragment } = render(
+      <InfoList infoData={[{ title: 'Item 1', content: undefined }]} columns />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render title that is a React Node', () => {
+    const { asFragment } = render(
+      <InfoList
+        infoData={[
+          { title: <div>Item 1</div>, content: <div>Some content</div> },
+        ]}
+      />
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/decorated-list-item.tsx
+++ b/src/components/decorated-list-item.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import cn from 'classnames';
 
 import '../styles/components/decorated-list-item.scss';
@@ -7,7 +7,7 @@ type Props = {
   /**
    * Title
    */
-  title?: string;
+  title?: ReactNode;
   /**
    * Make this item visually stand-out
    */

--- a/src/components/info-list.tsx
+++ b/src/components/info-list.tsx
@@ -5,11 +5,13 @@ import DecoratedListItem from './decorated-list-item';
 
 import '../styles/components/info-list.scss';
 
+type Item = { title: ReactNode; content: ReactNode; key?: string };
+
 type Props = {
   /**
    * An array of objects each containing 'title' and 'content'
    */
-  infoData: Array<{ title: string; content: ReactNode }>;
+  infoData: Array<Item>;
   /**
    * A boolean indicating whether the component should span multiple
    * columns on medium to large screens or not.
@@ -51,17 +53,16 @@ const InfoList: FC<Props> = ({
   >
     {infoData.map(
       // Only draw if there is content
-      (item, index) =>
-        item.content && (
-          <li key={item.title}>
+      ({ content, title, key }, index) =>
+        content && (
+          <li key={key || (typeof title === 'string' ? title : index)}>
             <DecoratedListItem
-              title={item.title}
+              title={title}
               highlight={index === 0 && highlightFirstItem}
               compact={isCompact}
               hideTitle={noTitles}
-              key={item.title}
             >
-              {item.content}
+              {content}
             </DecoratedListItem>
           </li>
         )

--- a/stories/InfoList.stories.tsx
+++ b/stories/InfoList.stories.tsx
@@ -1,6 +1,6 @@
 import { loremIpsum } from 'lorem-ipsum';
 
-import { InfoList } from '../src/components';
+import { InfoList, SwissProtIcon } from '../src/components';
 
 export default {
   title: 'Data/Info List',
@@ -25,6 +25,14 @@ const data = [
   },
   {
     title: 'Yet another item',
+    content: loremIpsum({ count: 25, units: 'words' }),
+  },
+  {
+    title: (
+      <>
+        <SwissProtIcon width={16} height={16} /> An item with JSX
+      </>
+    ),
     content: loremIpsum({ count: 25, units: 'words' }),
   },
 ];


### PR DESCRIPTION
## Purpose
There is a new requirement to render React Nodes in the InfoList's entry title as seen in this mockup:
<img width="1156" alt="Screenshot 2021-03-08 at 16 48 18" src="https://user-images.githubusercontent.com/4357962/110352731-2a368880-802e-11eb-9937-ab405457be4e.png">


## Approach

- Render ReactNode in InfoList entry title.
- Allow passing keys to accommodate this change.

## Testing
Snapshot

## Stories
Added to the existing story.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
