### PR TITLE
Header secondary nav

### DIFF
--- a/src/components/__tests__/__snapshots__/header.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/header.spec.tsx.snap
@@ -68,7 +68,59 @@ exports[`Header component should render 1`] = `
     </ul>
     <div
       class="header__search"
-    />
+    >
+      <form
+        class="main-search"
+        data-testid="main-search-form"
+        style="--main-button-color: #00639a;"
+      >
+        <input
+          aria-label="Text query"
+          class="main-search__input"
+          data-testid="main-search-input"
+          type="text"
+          value=""
+        />
+        <button
+          class="button primary"
+          type="submit"
+        >
+          Search
+        </button>
+      </form>
+    </div>
+    <div
+      class="header__secondary"
+    >
+      <ul
+        class="header__navigation"
+      >
+        <li>
+          <a
+            class="button tertiary"
+            href="/"
+          >
+            <test-file-stub />
+          </a>
+        </li>
+        <li>
+          <a
+            class="button tertiary"
+            href="/"
+          >
+            <test-file-stub />
+          </a>
+        </li>
+        <li>
+          <a
+            class="button tertiary"
+            href="/"
+          >
+            <test-file-stub />
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/__tests__/header.spec.tsx
+++ b/src/components/__tests__/header.spec.tsx
@@ -1,3 +1,4 @@
+import { BasketIcon, EnvelopeIcon, HelpIcon, MainSearch } from '..';
 import renderWithRouter from '../../testHelpers/renderWithRouter';
 
 import Header from '../header';
@@ -19,6 +20,12 @@ describe('Header component', () => {
             label: 'sub links',
           },
         ]}
+        secondaryItems={[
+          { label: <HelpIcon />, path: '/' },
+          { label: <EnvelopeIcon />, path: '/' },
+          { label: <BasketIcon />, path: '/' },
+        ]}
+        search={<MainSearch onChange={jest.fn()} onSubmit={jest.fn()} />}
       />
     );
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -64,6 +64,33 @@ const HeaderItem: FC<HeaderItemProps> = ({ item }) => {
   );
 };
 
+const HeaderListItem: FC<{
+  item: HeaderPossibleItem | HeaderDropdown;
+  isNegative: boolean;
+}> = ({ item, isNegative }) => (
+  <li>
+    {item.items ? (
+      <DropdownButton
+        label={item.label}
+        className={cn({
+          'dropdown-container__trigger--negative': isNegative,
+        })}
+        openOnHover
+      >
+        <ul>
+          {item.items.map((subItem, index) => (
+            <li key={typeof subItem.label === 'string' ? subItem.label : index}>
+              <HeaderItem item={subItem} />
+            </li>
+          ))}
+        </ul>
+      </DropdownButton>
+    ) : (
+      <HeaderItem item={item as HeaderPossibleItem} />
+    )}
+  </li>
+);
+
 type HeaderProps = {
   /**
    * Logo to display where the link to the home page will be
@@ -78,45 +105,58 @@ type HeaderProps = {
    */
   search?: ReactNode;
   /**
+   * Secondary items
+   */
+  secondaryItems?: Array<HeaderPossibleItem | HeaderDropdown>;
+  /**
+   * Subtext
+   */
+  subtext?: ReactNode;
+  /**
    * Flag representing if the header should be in a "negative" style
    */
   isNegative?: boolean;
 };
-const Header: FC<HeaderProps> = ({ logo, items, search, isNegative }) => (
+const Header: FC<HeaderProps> = ({
+  logo,
+  items,
+  search,
+  secondaryItems,
+  subtext,
+  isNegative = false,
+}) => (
   <div className={cn('header', { 'header--negative': isNegative })}>
     <div className="header__logo">
       <Link to="/">{logo}</Link>
     </div>
     <ul className="header__navigation">
       {items.map((item, index) => (
-        <li key={typeof item.label === 'string' ? item.label : index}>
-          {item.items ? (
-            <DropdownButton
-              label={item.label}
-              className={cn({
-                'dropdown-container__trigger--negative': isNegative,
-              })}
-              openOnHover
-            >
-              <ul>
-                {item.items.map((subItem, index) => (
-                  <li
-                    key={
-                      typeof subItem.label === 'string' ? subItem.label : index
-                    }
-                  >
-                    <HeaderItem item={subItem} />
-                  </li>
-                ))}
-              </ul>
-            </DropdownButton>
-          ) : (
-            <HeaderItem item={item as HeaderPossibleItem} />
-          )}
-        </li>
+        <HeaderListItem
+          item={item}
+          key={typeof item.label === 'string' ? item.label : index}
+          isNegative={isNegative}
+        />
       ))}
     </ul>
     <div className="header__search">{search}</div>
+    {secondaryItems && (
+      <div className="header__secondary">
+        <ul className="header__navigation">
+          {secondaryItems.map((item, index) => (
+            <HeaderListItem
+              item={item}
+              key={
+                typeof item.label === 'string'
+                  ? item.label
+                  : `secondary_${index}`
+              }
+              isNegative={isNegative}
+            />
+          ))}
+        </ul>
+        {subtext && <small>{subtext}</small>}
+      </div>
+    )}
   </div>
 );
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -86,6 +86,7 @@ export { default as WarningTriangleIcon } from '../svg/warning-triangle.svg';
 export { default as ZoomIn } from '../svg/zoom-in.svg';
 export { default as ZoomOut } from '../svg/zoom-out.svg';
 export { default as ZoomToSequence } from '../svg/zoom-to-sequence.svg';
+export { default as HelpIcon } from '../svg/help.svg';
 
 // Sequence Utilities
 export { formatFASTA, extractNameFromFASTAHeader } from '../sequence-utils';

--- a/src/styles/components/header.scss
+++ b/src/styles/components/header.scss
@@ -112,6 +112,27 @@ $content-width: 90%;
     }
   }
 
+  &__secondary {
+    text-align: right;
+    .header__navigation {
+      display: flex;
+      justify-content: flex-end;
+      a.button,
+      button.button {
+        // margin: 0;
+        padding: 0 0.1rem;
+        svg {
+          margin: 0;
+        }
+      }
+    }
+    small {
+      display: block;
+      // Magic number to reduce spacing
+      margin-top: -0.2rem;
+    }
+  }
+
   &__search {
     flex: 4 4 auto;
     input,

--- a/src/svg/help.svg
+++ b/src/svg/help.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9 5a1 1 0 11-2 0 1 1 0 012 0zM9 7v5H7V7h2z"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M16 8A8 8 0 110 8a8 8 0 0116 0zm-2 0A6 6 0 112 8a6 6 0 0112 0z"/>
+</svg>

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,7 +1,13 @@
 import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { Header, MainSearch } from '../src/components';
+import {
+  BasketIcon,
+  EnvelopeIcon,
+  Header,
+  HelpIcon,
+  MainSearch,
+} from '../src/components';
 
 import UniProtLogo from '../src/svg/swissprot.svg';
 
@@ -15,7 +21,7 @@ export default {
   },
 };
 
-const items = [
+const headerItems = [
   { label: 'Link 1', path: '/' },
   {
     label: 'Links 2',
@@ -29,6 +35,12 @@ const items = [
   },
   { label: 'Link 3', path: '/' },
   { label: 'action', onClick: action('onClick') },
+];
+
+const headerSecondaryItems = [
+  { label: <HelpIcon />, path: '/' },
+  { label: <EnvelopeIcon />, path: '/' },
+  { label: <BasketIcon />, path: '/' },
 ];
 
 const Search = () => {
@@ -46,14 +58,29 @@ const Search = () => {
 };
 
 export const header = () => (
-  <Header logo={<UniProtLogo width={30} />} items={items} search={<Search />} />
+  <Header
+    logo={<UniProtLogo width={30} />}
+    items={headerItems}
+    search={<Search />}
+  />
 );
 
 export const headerNegative = () => (
   <Header
     logo={<UniProtLogo width={30} />}
-    items={items}
+    items={headerItems}
     search={<Search />}
+    secondaryItems={headerSecondaryItems}
+    isNegative
+  />
+);
+
+export const headerWithSecondaryNav = () => (
+  <Header
+    logo={<UniProtLogo width={30} />}
+    items={headerItems}
+    secondaryItems={headerSecondaryItems}
+    subtext="Release info | Statistics"
     isNegative
   />
 );

--- a/stories/Icons.stories.tsx
+++ b/stories/Icons.stories.tsx
@@ -42,6 +42,7 @@ import {
   ZoomIn,
   ZoomOut,
   ZoomToSequence,
+  HelpIcon,
 } from '../src/components';
 
 import colors from '../src/styles/colours.json';
@@ -257,6 +258,11 @@ const iconDefinition = [
     name: 'envelope.svg',
     description: 'Envelope',
     icon: <EnvelopeIcon width={size} height={size} />,
+  },
+  {
+    name: 'help.svg',
+    description: 'Help',
+    icon: <HelpIcon width={size} height={size} />,
   },
 ];
 


### PR DESCRIPTION
## Purpose
Add a secondary navigation section in the header component. This will be used on the website to link to help, contact. Also add a `subtext` which will be used for the release and statistics link.

## Approach
Add optional props

## Testing
Added to the render test

## Stories
Added example to storybook stories

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [] For the stories you created/updated, are the props modifiables through knobs?
