### PR TITLE
Make description slide a prop

### DIFF
--- a/src/components/tile.tsx
+++ b/src/components/tile.tsx
@@ -38,6 +38,11 @@ type Props = (LinkProps | ExternalLinkProps) & {
    * width of the provided container.
    */
   width?: string;
+  /**
+   * Whether to slide up the description when the mouse is over the tile.
+   * Can be useful if the description text is long.
+   */
+  descriptionSlideUp?: boolean;
 };
 
 const nextHeading = (level: Exclude<HeadingLevels, 'h6'>) =>
@@ -54,6 +59,7 @@ export const Tile: FC<Props> = ({
   className,
   style,
   children,
+  descriptionSlideUp = false,
   ...props
 }) => {
   const isExternal = 'url' in props;
@@ -97,7 +103,16 @@ export const Tile: FC<Props> = ({
           {mainContent}
         </Link>
       )}
-      {children && <small className="tile__description">{children}</small>}
+      {children && (
+        <small
+          className={cn(
+            'tile__description',
+            descriptionSlideUp && 'tile__description--animated'
+          )}
+        >
+          {children}
+        </small>
+      )}
     </div>
   );
 };

--- a/src/styles/components/tile.scss
+++ b/src/styles/components/tile.scss
@@ -48,7 +48,9 @@ $tile: '.tile';
   }
 
   &__description {
-    transition: transform $animation-time linear;
+    &--animated {
+      transition: transform $animation-time linear;
+    }
     display: block;
     padding: 0.7rem;
     line-height: 1.6;

--- a/src/styles/components/tile.scss
+++ b/src/styles/components/tile.scss
@@ -95,7 +95,7 @@ $tile: '.tile';
       outline-offset: -1ch;
     }
 
-    #{$tile}__description {
+    #{$tile}__description--animated {
       transform: translateY(0);
       overflow-y: auto;
     }

--- a/stories/Tile.stories.tsx
+++ b/stories/Tile.stories.tsx
@@ -40,6 +40,7 @@ export const BasicTile = () => (
     width="20rem"
     gradient={boolean('gradient', false, 'Props')}
     to="/"
+    descriptionSlideUp={boolean('Slide up description', false, 'Props')}
   >
     {loremIpsum()}
     {boolean('button in description', false) ? (


### PR DESCRIPTION
## Purpose
Description slide up is not currently useful for the uniprot-website, so we should have this has an option.

## Approach
Add a new prop to toggle description slide on/off

## Testing
What test(s) did you write to validate and verify your changes?
Visual

## Stories
What story(ies) did you write or change to document the functionality / changes?
added a knob in the story

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
