### PR TITLE
add micro header

### DIFF
--- a/markdown/typography.md
+++ b/markdown/typography.md
@@ -2,19 +2,23 @@
 
 ## Headers
 
-# h1. This is a very large header
+<h1>This is a very large header (h1 or .huge)</h1>
+<h1 class="bold">This is a very large bold header (h1 or .huge)</h1>
 
-## h2. This is a large header
+<h2>This is a large header (h2 or .big)</h2>
+<h2 class="bold">This is a large bold header (h2 or .big)</h2>
 
-### h3. This is a medium header
+<h3>This is a medium header (h3 or .medium)</h3>
+<h3 class="bold">This is a medium bold header (h3 or .medium)</h3>
 
-<h3 class="bold">h3.bold This is a medium header (strong)</h3>
+<h4>This is a moderate header (h4 or .small)</h4>
+<h4 class="bold">This is a moderate bold header (h4 or .small)</h4>
 
-#### h4. This is a moderate header
+<h5>This is a tiny header (h5 or .tiny)</h5>
+<h5 class="bold">This is a tiny bold header (h5 or .tiny)</h5>
 
-##### h5. This is a small header
-
-<h5 class="bold">h5.bold This is a small header (strong)</h5>
+<h6>This is a tinier header (h6 or .micro)</h6>
+<h6 class="bold">This is a tinier bold header (h6 or .micro)</h6>
 
 ## Paragraphs
 

--- a/src/styles/_franklin-settings.scss
+++ b/src/styles/_franklin-settings.scss
@@ -155,6 +155,32 @@ $fs-font-values: (
       0.5rem,
     ),
   ),
+  'H6': (
+    'small': (
+      16px,
+      1 * 0.5rem,
+      1.7,
+      -0.04rem,
+      'semi-bold',
+      0.5rem,
+    ),
+    'medium': (
+      16px,
+      1 * 0.8rem,
+      1.7,
+      -0.04rem,
+      'semi-bold',
+      0.5rem,
+    ),
+    'large': (
+      16px,
+      1rem,
+      1.7,
+      -0.04rem,
+      'semi-bold',
+      0.5rem,
+    ),
+  ),
 );
 
 // Breakpoints

--- a/src/styles/common/_typography.scss
+++ b/src/styles/common/_typography.scss
@@ -62,6 +62,13 @@ h5,
     font-weight: font-weight('bold');
   }
 }
+h6,
+.micro {
+  @include fs-font-settings('H6');
+  &.bold {
+    font-weight: font-weight('bold');
+  }
+}
 p {
   margin-bottom: 1.875rem;
 }


### PR DESCRIPTION
## Purpose
Need a smaller header level, the same size as normal text

## Approach
Add a smaller level of heading, assigned to `<h6>` or `.micro`

## Testing
No test

## Stories
Typography

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
