### PR TITLE
refactor cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 81.41,
-        "statements": 81,
+        "lines": 81.39,
+        "statements": 80.98,
         "functions": 77.41,
-        "branches": 71.25
+        "branches": 71.09
       }
     },
     "setupFilesAfterEnv": [

--- a/src/components/__tests__/__snapshots__/card.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/card.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`Card component should render 1`] = `
       class="card__container"
     >
       <div
-        class="card__header"
+        class="card__header card__header--with-separator"
       >
         <h2>
           Title
@@ -36,7 +36,7 @@ exports[`Card component should render card with links 1`] = `
       class="card__container"
     >
       <div
-        class="card__header"
+        class="card__header card__header--with-separator"
       >
         <h2>
           Title
@@ -81,7 +81,7 @@ exports[`Card component should render card with target 1`] = `
       class="card__container"
     >
       <div
-        class="card__header"
+        class="card__header card__header--with-separator"
       >
         <h2>
           Title

--- a/src/components/__tests__/__snapshots__/card.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/card.spec.tsx.snap
@@ -5,13 +5,13 @@ exports[`Card component should render 1`] = `
   <section
     class="card"
   >
-    <div>
+    <div
+      class="card__container"
+    >
       <div
         class="card__header"
       >
-        <h2
-          class="card__title"
-        >
+        <h2>
           Title
         </h2>
       </div>
@@ -32,20 +32,15 @@ exports[`Card component should render card with links 1`] = `
   <section
     class="card"
   >
-    <div>
+    <div
+      class="card__container"
+    >
       <div
         class="card__header"
       >
-        <h2
-          class="card__title"
-        >
+        <h2>
           Title
         </h2>
-        <div
-          class="card__subtitle"
-        >
-          Subtitle
-        </div>
       </div>
       <div
         class="card__content"
@@ -59,7 +54,7 @@ exports[`Card component should render card with links 1`] = `
       class="card__actions"
     >
       <a
-        class="card__link"
+        class="card-action"
         href="/example.com"
         style="border-bottom: 0.125rem solid red;"
       >
@@ -70,61 +65,27 @@ exports[`Card component should render card with links 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Card component should render card with onclick 1`] = `
+exports[`Card component should render card with target 1`] = `
 <DocumentFragment>
   <section
-    class="card"
+    class="card card--has-link"
   >
+    <a
+      aria-hidden="true"
+      class="card__link"
+      data-testid="background-link"
+      href="/target"
+      tabindex="-1"
+    />
     <div
-      class="card--has-hover"
-      role="button"
-      tabindex="0"
+      class="card__container"
     >
       <div
         class="card__header"
       >
-        <h2
-          class="card__title"
-        >
+        <h2>
           Title
         </h2>
-        <div
-          class="card__subtitle"
-        >
-          Subtitle
-        </div>
-      </div>
-      <div
-        class="card__content"
-      >
-        <span>
-          Some content
-        </span>
-      </div>
-    </div>
-  </section>
-</DocumentFragment>
-`;
-
-exports[`Card component should render card with subtitle 1`] = `
-<DocumentFragment>
-  <section
-    class="card"
-  >
-    <div>
-      <div
-        class="card__header"
-      >
-        <h2
-          class="card__title"
-        >
-          Title
-        </h2>
-        <div
-          class="card__subtitle"
-        >
-          Subtitle
-        </div>
       </div>
       <div
         class="card__content"

--- a/src/components/__tests__/card.spec.tsx
+++ b/src/components/__tests__/card.spec.tsx
@@ -7,16 +7,7 @@ import renderWithRouter from '../../testHelpers/renderWithRouter';
 describe('Card component', () => {
   test('should render', () => {
     const { asFragment } = renderWithRouter(
-      <Card title="Title">
-        <span>Some content</span>
-      </Card>
-    );
-    expect(asFragment()).toMatchSnapshot();
-  });
-
-  test('should render card with subtitle', () => {
-    const { asFragment } = renderWithRouter(
-      <Card title="Title" subtitle="Subtitle">
+      <Card header={<h2>Title</h2>}>
         <span>Some content</span>
       </Card>
     );
@@ -33,22 +24,21 @@ describe('Card component', () => {
     ];
 
     const { asFragment } = renderWithRouter(
-      <Card title="Title" subtitle="Subtitle" links={links}>
+      <Card header={<h2>Title</h2>} links={links}>
         <span>Some content</span>
       </Card>
     );
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('should render card with onclick', () => {
-    const onClickMock = jest.fn();
-    const { asFragment } = renderWithRouter(
-      <Card title="Title" subtitle="Subtitle" onClick={onClickMock}>
+  test('should render card with target', () => {
+    const { asFragment, history } = renderWithRouter(
+      <Card header={<h2>Title</h2>} to="/target">
         <span>Some content</span>
       </Card>
     );
-    fireEvent.click(screen.getByRole('button'));
-    expect(onClickMock).toHaveBeenCalled();
     expect(asFragment()).toMatchSnapshot();
+    fireEvent.click(screen.getByTestId('background-link'));
+    expect(history.location.pathname).toBe('/target');
   });
 });

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -43,11 +43,6 @@ type Props = {
    */
   links?: Array<CardActionProps>;
   /**
-   * Should the card styling show it as active or not
-   */
-  // TODO: where is that used?
-  active?: boolean;
-  /**
    * Target/link of the card when clicking on it
    */
   to?: LinkProps['to'];
@@ -61,7 +56,6 @@ const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
       children,
       links,
       to,
-      active,
       className,
       ...props
     },
@@ -69,7 +63,6 @@ const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
   ) => (
     <section
       className={cn(className, 'card', {
-        'card--active': active,
         'card--has-link': to,
       })}
       ref={ref}

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -35,6 +35,10 @@ type Props = {
    */
   header?: ReactNode;
   /**
+   * Does the card header need a separator? Defaults to true
+   */
+  headerSeparator?: boolean;
+  /**
    * Links to be displayed at the bottom of the card
    */
   links?: Array<CardActionProps>;
@@ -50,7 +54,19 @@ type Props = {
 };
 
 const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
-  ({ header, children, links, to, active, className, ...props }, ref) => (
+  (
+    {
+      header,
+      headerSeparator = true,
+      children,
+      links,
+      to,
+      active,
+      className,
+      ...props
+    },
+    ref
+  ) => (
     <section
       className={cn(className, 'card', {
         'card--active': active,
@@ -69,7 +85,15 @@ const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
         />
       )}
       <div className="card__container">
-        {header && <div className="card__header">{header}</div>}
+        {header && (
+          <div
+            className={cn('card__header', {
+              'card__header--with-separator': headerSeparator,
+            })}
+          >
+            {header}
+          </div>
+        )}
         <div className="card__content">{children}</div>
       </div>
       {links?.length ? (

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -56,6 +56,10 @@ $card-link-padding: 0.5rem;
     align-items: baseline;
     padding-left: $global-padding;
 
+    &--with-separator {
+      border-bottom: 0.125rem solid $colour-platinum;
+    }
+
     & > * {
       margin: 0;
     }
@@ -64,7 +68,7 @@ $card-link-padding: 0.5rem;
       margin-right: $global-margin;
     }
 
-    & + .card__content {
+    &:not(&--with-separator) + .card__content {
       padding-top: 0;
     }
   }

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -11,21 +11,39 @@ $card-link-padding: 0.5rem;
   border-radius: 0.2rem;
   margin: $global-margin $shadow-padding;
   width: calc(100% - #{$global-padding});
+  position: relative;
 
-  &--has-hover:hover {
-    background-color: scale-color($color: $colour-platinum, $lightness: 40%);
-    transition: 0.5s background-color ease;
+  &__link {
+    z-index: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
     cursor: pointer;
   }
 
-  &__header {
-    padding-left: $global-padding;
+  &__container {
+    position: relative;
+  }
 
-    &__checkbox {
-      input[type='checkbox'] {
-        margin: 0 0.75rem 0.5rem 0;
-        vertical-align: middle;
-      }
+  &--has-link {
+    transition: 0.5s background-color ease;
+
+    &:hover,
+    &:focus-within,
+    .card--active {
+      background-color: scale-color($color: $colour-platinum, $lightness: 40%);
+    }
+
+    * {
+      pointer-events: none;
+    }
+
+    a,
+    button,
+    input {
+      pointer-events: initial;
     }
   }
 
@@ -33,16 +51,22 @@ $card-link-padding: 0.5rem;
     padding: $global-padding;
   }
 
-  &__title {
-    margin: 0;
-    margin-right: $global-margin;
-  }
-
   &__header {
     display: flex;
     align-items: baseline;
-    border-bottom: 0.125rem solid;
-    border-color: $colour-platinum;
+    padding-left: $global-padding;
+
+    & > * {
+      margin: 0;
+    }
+
+    & > *:not(:last-child) {
+      margin-right: $global-margin;
+    }
+
+    & + .card__content {
+      padding-top: 0;
+    }
   }
 
   &__actions {
@@ -53,20 +77,18 @@ $card-link-padding: 0.5rem;
     padding: 0;
     background-color: $colour-selected;
   }
-
-  &--active {
-    background-color: scale-color($color: $colour-platinum, $lightness: 20%);
-  }
 }
 
-.card__link {
+.card-action {
   margin: 0;
   padding: $card-link-padding;
   font-weight: 600;
   white-space: nowrap;
   background-color: $colour-gainsborough;
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &:focus-within {
     transition: 0.5s background-color ease;
     background-color: $colour-hover;
   }

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -31,8 +31,7 @@ $card-link-padding: 0.5rem;
     transition: 0.5s background-color ease;
 
     &:hover,
-    &:focus-within,
-    .card--active {
+    &:focus-within {
       background-color: scale-color($color: $colour-platinum, $lightness: 40%);
     }
 

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -1,6 +1,7 @@
-import { Link } from 'react-router-dom';
-import { action } from '@storybook/addon-actions';
-import { Card } from '../src/components';
+import { boolean } from '@storybook/addon-knobs';
+
+import { Card as CardComponent, SwissProtIcon } from '../src/components';
+
 import { getLipsumSentences } from '../src/mock-data/lipsum';
 
 const links = [
@@ -24,6 +25,15 @@ const links = [
     link: '/burlywood',
     color: 'burlywood',
   },
+  {
+    key: 'swissprot',
+    name: (
+      <>
+        <SwissProtIcon width="1.5ch" /> Reviewed
+      </>
+    ),
+    link: '/reviewed',
+  },
 ];
 
 export default {
@@ -38,30 +48,29 @@ export default {
   },
 };
 
-export const card = () => (
-  <Card title="Title" subtitle={<a href="/#">APOE_HUMAN - P02649</a>}>
-    {getLipsumSentences()}
-  </Card>
-);
-
-export const cardWithOnClick = () => (
-  <Card title="Title" onClick={action('click')} links={links}>
-    {getLipsumSentences()}
-  </Card>
-);
-
-export const cardWithLinks = () => (
-  <Card
-    title="Title"
-    subtitle={<Link to="/#">APOE_HUMAN - P02649</Link>}
-    links={links}
-  >
-    {getLipsumSentences()}
-  </Card>
-);
-
-export const activeCard = () => (
-  <Card title="Title" onClick={action('click')} active>
-    {getLipsumSentences()}
-  </Card>
-);
+export const Card = () => {
+  const hasHeader = boolean('header', true, 'Props');
+  const hasCheckbox = boolean('checkbox (only if header)', false, 'Props');
+  return (
+    <CardComponent
+      header={
+        hasHeader ? (
+          <>
+            {hasCheckbox && <input type="checkbox" />}
+            <h2>
+              Title{' '}
+              <a className="medium" href="/#">
+                APOE_HUMAN - P02649
+              </a>
+            </h2>
+          </>
+        ) : undefined
+      }
+      to={boolean('to', false, 'Props') ? '#' : undefined}
+      links={boolean('links', false, 'Props') ? links : undefined}
+      active={boolean('active', false, 'Props')}
+    >
+      {getLipsumSentences()}
+    </CardComponent>
+  );
+};

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -50,6 +50,7 @@ export default {
 
 export const Card = () => {
   const hasHeader = boolean('header', true, 'Props');
+  const hasHeaderSeparator = boolean('headerSeparator', true, 'Props');
   const hasCheckbox = boolean('checkbox (only if header)', false, 'Props');
   return (
     <CardComponent
@@ -66,6 +67,7 @@ export const Card = () => {
           </>
         ) : undefined
       }
+      headerSeparator={hasHeaderSeparator}
       to={boolean('to', false, 'Props') ? '#' : undefined}
       links={boolean('links', false, 'Props') ? links : undefined}
       active={boolean('active', false, 'Props')}

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -70,7 +70,6 @@ export const Card = () => {
       headerSeparator={hasHeaderSeparator}
       to={boolean('to', false, 'Props') ? '#' : undefined}
       links={boolean('links', false, 'Props') ? links : undefined}
-      active={boolean('active', false, 'Props')}
     >
       {getLipsumSentences()}
     </CardComponent>


### PR DESCRIPTION
## Purpose
Refactor Card component

## Approach
- Accept ReactNode as text for the links at the bottom of a card
- Replace title and subtitle with generic header prop (responsibility of the user of the component to use the correct heading level)
- Made header separator optional (through props)
- Remove the onClick in favour of using a proper link in the back
- Let the clicks go through to the new background link, except for `<a>`, `<button>`, and `<input>`.
- Removed all but one story, use knobs

## Testing
Updated tests and snapshots

## Stories
Card

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
  - Reduced codebase
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?

Doubts: Is the `active` prop useful/used anywhere?
