### PR TITLE
Evidence tag changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 81.39,
-        "statements": 80.98,
+        "lines": 81.36,
+        "statements": 80.95,
         "functions": 77.41,
         "branches": 71.09
       }

--- a/src/components/__tests__/__snapshots__/evidence-tag.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/evidence-tag.spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`EvidenceTag component should render tag and toggle visibility of conten
   <button
     aria-controls="abcd"
     aria-expanded="true"
-    class="evidence-tag "
+    class="evidence-tag"
     data-testid="evidence-tag-trigger"
     type="button"
   >

--- a/src/components/__tests__/__snapshots__/evidence-tag.spec.jsx.snap
+++ b/src/components/__tests__/__snapshots__/evidence-tag.spec.jsx.snap
@@ -15,7 +15,6 @@ exports[`EvidenceTag component should render tag and toggle visibility of conten
     />
     <span
       class="evidence-tag__label"
-      title="My title"
     >
       My evidence
     </span>

--- a/src/components/evidence-tag.tsx
+++ b/src/components/evidence-tag.tsx
@@ -1,5 +1,12 @@
-import { useState, useRef, cloneElement } from 'react';
-import PropTypes from 'prop-types';
+import {
+  useState,
+  useRef,
+  cloneElement,
+  ReactNode,
+  FC,
+  ReactElement,
+} from 'react';
+import cn from 'classnames';
 import { v1 } from 'uuid';
 
 import EvidenceTagIcon from '../svg/evidence-tag.svg';
@@ -8,13 +15,42 @@ import '../styles/components/evidence-tag.scss';
 
 const size = 12;
 
-const EvidenceTag = ({ label, title, className, iconComponent, children }) => {
+type EvidenceTagProps = {
+  /**
+   * Displayed on the tag
+   */
+  label: string;
+  /**
+   * Displayed on on mouseover
+   */
+  title: string;
+  /**
+   * Decides the colour of the tag
+   */
+  className?: string;
+  /**
+   * Decides the colour of the tag
+   */
+  iconComponent: ReactElement<{ width: number; height: number }>;
+  /**
+   * The content of the tag
+   */
+  children: ReactNode;
+};
+
+const EvidenceTag: FC<EvidenceTagProps> = ({
+  label,
+  title,
+  className,
+  iconComponent = <EvidenceTagIcon />,
+  children,
+}) => {
   const idRef = useRef(v1());
   const [contentDisplay, setContentDisplay] = useState(false);
   return (
     <>
       <button
-        className={`evidence-tag ${className}`}
+        className={cn(className, 'evidence-tag')}
         onClick={() => setContentDisplay(!contentDisplay)}
         type="button"
         data-testid="evidence-tag-trigger"
@@ -39,39 +75,6 @@ const EvidenceTag = ({ label, title, className, iconComponent, children }) => {
       )}
     </>
   );
-};
-
-EvidenceTag.propTypes = {
-  /**
-   * Displayed on the tag
-   */
-  label: PropTypes.string.isRequired,
-  /**
-   * Displayed on on mouseover
-   */
-  title: PropTypes.string,
-  /**
-   * Decides the colour of the tag
-   */
-  className: PropTypes.string,
-  /**
-   * Decides the colour of the tag
-   */
-  iconComponent: PropTypes.element,
-  /**
-   * The content of the tag
-   */
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]),
-};
-
-EvidenceTag.defaultProps = {
-  title: '',
-  className: '',
-  iconComponent: <EvidenceTagIcon />,
-  children: null,
 };
 
 export default EvidenceTag;

--- a/src/components/evidence-tag.tsx
+++ b/src/components/evidence-tag.tsx
@@ -32,10 +32,6 @@ type EvidenceTagProps = {
    * Decides the colour of the tag
    */
   iconComponent: ReactElement<{ width: number; height: number }>;
-  /**
-   * The content of the tag
-   */
-  children: ReactNode;
 };
 
 const EvidenceTag: FC<EvidenceTagProps> = ({

--- a/src/components/evidence-tag.tsx
+++ b/src/components/evidence-tag.tsx
@@ -21,14 +21,6 @@ type EvidenceTagProps = {
    */
   label: string;
   /**
-   * Displayed on on mouseover
-   */
-  title: string;
-  /**
-   * Decides the colour of the tag
-   */
-  className?: string;
-  /**
    * Decides the colour of the tag
    */
   iconComponent: ReactElement<{ width: number; height: number }>;
@@ -56,9 +48,7 @@ const EvidenceTag: FC<EvidenceTagProps & HTMLAttributes<HTMLButtonElement>> = ({
         {...props}
       >
         {cloneElement(iconComponent, { width: size, height: size })}
-        <span className="evidence-tag__label" title={title}>
-          {label}
-        </span>
+        <span className="evidence-tag__label">{label}</span>
       </button>
       {children && (
         <div

--- a/src/components/evidence-tag.tsx
+++ b/src/components/evidence-tag.tsx
@@ -2,9 +2,9 @@ import {
   useState,
   useRef,
   cloneElement,
-  ReactNode,
   FC,
   ReactElement,
+  HTMLAttributes,
 } from 'react';
 import cn from 'classnames';
 import { v1 } from 'uuid';
@@ -34,12 +34,13 @@ type EvidenceTagProps = {
   iconComponent: ReactElement<{ width: number; height: number }>;
 };
 
-const EvidenceTag: FC<EvidenceTagProps> = ({
+const EvidenceTag: FC<EvidenceTagProps & HTMLAttributes<HTMLButtonElement>> = ({
   label,
   title,
   className,
   iconComponent = <EvidenceTagIcon />,
   children,
+  ...props
 }) => {
   const idRef = useRef(v1());
   const [contentDisplay, setContentDisplay] = useState(false);
@@ -52,6 +53,7 @@ const EvidenceTag: FC<EvidenceTagProps> = ({
         data-testid="evidence-tag-trigger"
         aria-expanded={contentDisplay}
         aria-controls={idRef.current}
+        {...props}
       >
         {cloneElement(iconComponent, { width: size, height: size })}
         <span className="evidence-tag__label" title={title}>

--- a/src/styles/components/evidence-tag.scss
+++ b/src/styles/components/evidence-tag.scss
@@ -12,9 +12,20 @@
   line-height: 1.25rem;
   margin-left: ($global-margin/2);
   border-radius: $global-padding/4;
-  background-color: $colour-platinum;
+  background-color: $colour-gainsborough;
+  border: 1px solid $colour-weldon-blue;
   padding: 0 $global-padding/4;
   color: $colour-yankees-blue;
+
+  &:hover,
+  &:focus,
+  &:focus-within {
+    background-color: $colour-pastel-blue;
+  }
+
+  &:active {
+    background-color: rgba($colour-independence, 0.3);
+  }
 
   svg {
     position: absolute;

--- a/stories/EvidenceTag.stories.jsx
+++ b/stories/EvidenceTag.stories.jsx
@@ -1,8 +1,10 @@
-import { EvidenceTag } from '../src/components';
+import { withKnobs, text, select } from '@storybook/addon-knobs';
+import { EvidenceTag, EvidenceTagIcon, HelpIcon } from '../src/components';
 import { getLipsumSentences } from '../src/mock-data/lipsum';
 
 export default {
   title: 'Biocomponents/Evidence Tag',
+  decorators: [withKnobs()],
   parameters: {
     purposeFunction: {
       function:
@@ -13,8 +15,21 @@ export default {
   },
 };
 
+const IconComponentOptions = {
+  EvidenceTag: <EvidenceTagIcon />,
+  HelpIcon: <HelpIcon />,
+};
+
 export const evidenceTag = () => (
-  <EvidenceTag label="Evidence tag">
+  <EvidenceTag
+    label={text('label', 'this is an evidence tag', 'Props')}
+    title="Tag title"
+    iconComponent={
+      IconComponentOptions[
+        select('iconComponent', ['EvidenceTag', 'HelpIcon'], null, 'Props')
+      ]
+    }
+  >
     <div>
       <h5>Some title</h5>
       <p>{getLipsumSentences()}</p>

--- a/stories/EvidenceTag.stories.jsx
+++ b/stories/EvidenceTag.stories.jsx
@@ -23,7 +23,6 @@ const IconComponentOptions = {
 export const evidenceTag = () => (
   <EvidenceTag
     label={text('label', 'this is an evidence tag', 'Props')}
-    title="Tag title"
     iconComponent={
       IconComponentOptions[
         select('iconComponent', ['EvidenceTag', 'HelpIcon'], null, 'Props')


### PR DESCRIPTION
## Purpose
New styling as defined in #188 

## Approach
Using pseudo-classes to define the new behaviour. I don't think `:active` is quite the behaviour defined by "when pressed" as it disappears after the click, but focus remains which I think is ok.
Move to TS (slight drop in coverage)

## Testing
Updated tests

## Stories
Added knobs to the story

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
