### PR TITLE
Allow tree-select item type to be extendable (while supporting a basic item type).

### DIFF
--- a/src/components/tree-select.tsx
+++ b/src/components/tree-select.tsx
@@ -3,8 +3,8 @@ import cn from 'classnames';
 import { Except } from 'type-fest';
 
 import {
+  BasicItem,
   getFlattenedPaths,
-  Item,
   restructureFlattenedTreeDataForAutocomplete,
 } from '../utils';
 import DropdownButton, { DropdownButtonProps } from './dropdown-button';
@@ -14,7 +14,7 @@ import Autocomplete from './autocomplete';
 import '../styles/components/tree-select.scss';
 import { AutocompleteItemType } from './autocomplete-item';
 
-export type TreeSelectProps = {
+export type TreeSelectProps<Item extends BasicItem<Item>> = {
   /**
    * The tree structure
    */
@@ -22,7 +22,7 @@ export type TreeSelectProps = {
   /**
    * What happens when something is selected
    */
-  onSelect: (item: Item) => void;
+  onSelect: (item: Omit<Item, 'items'>) => void;
   /**
    * Contains autocomplete functionality to search through tree
    */
@@ -44,7 +44,7 @@ export type TreeSelectProps = {
 
 type SetShowDropdownMenu = (show: boolean) => void;
 
-const TreeSelect = ({
+const TreeSelect = <Item extends BasicItem<Item>>({
   data,
   onSelect,
   autocomplete = false,
@@ -53,14 +53,15 @@ const TreeSelect = ({
   defaultActiveNodes = [],
   label,
   ...props
-}: Except<DropdownButtonProps, 'children' | 'label'> & TreeSelectProps) => {
+}: Except<DropdownButtonProps, 'children' | 'label'> &
+  TreeSelectProps<Item>) => {
   const [activeNodes, setActiveNodes] = useState(defaultActiveNodes);
-  const [openNodes, setOpenNodes] = useState<Item['id'][]>([]);
+  const [openNodes, setOpenNodes] = useState<BasicItem<Item>['id'][]>([]);
   const [autocompleteShowDropdown, setAutocompleteShowDropdown] =
     useState(false);
 
   const toggleNode = useCallback(
-    (node: AutocompleteItemType | Item) => {
+    (node: AutocompleteItemType | BasicItem<Item>) => {
       if (openNodes.includes(node.id)) {
         setOpenNodes(openNodes.slice(0, openNodes.indexOf(node.id)));
       } else {
@@ -72,7 +73,7 @@ const TreeSelect = ({
 
   const handleNodeClick = useCallback(
     (
-      node: AutocompleteItemType | Item | string,
+      node: AutocompleteItemType | BasicItem<Item> | string,
       setShowDropdownMenu: SetShowDropdownMenu
     ) => {
       // Don't register when user hasn't specifically selected something
@@ -94,7 +95,11 @@ const TreeSelect = ({
   );
 
   const buildTree = useCallback(
-    (items: Item[], setShowDropdownMenu: SetShowDropdownMenu, open = false) => (
+    (
+      items: BasicItem<Item>[],
+      setShowDropdownMenu: SetShowDropdownMenu,
+      open = false
+    ) => (
       <ul className={cn({ open })}>
         {items.map((node) => (
           <li key={node.id} className={cn({ branch: node.items })}>

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -5,23 +5,26 @@ export function getLastIndexOfSubstringIgnoreCase(
   return string.toLowerCase().lastIndexOf(substring.toLowerCase());
 }
 
-export type Item = {
+export type BasicItem<Item> = {
   label: string;
   id: string;
-  items?: Item[];
+  items?: BasicItem<Item>[];
 };
 
-export const getFlattenedPaths = (
+export const getFlattenedPaths = <Item extends BasicItem<Item>>(
   currentItems: Item[],
   id?: string,
   path: Item[] = []
 ) => {
-  let flattened: Pick<Item, 'label' | 'id'>[][] = [];
+  let flattened: Omit<Item, 'items'>[][] = [];
   currentItems.forEach((node) => {
     const { items, ...thisNode } = node;
     const nodePath = [...path, thisNode];
     if (items) {
-      const result = getFlattenedPaths(items, id, nodePath);
+      const result = getFlattenedPaths(items, id, nodePath) as Omit<
+        Item,
+        'items'
+      >[][];
       if (result.length) {
         flattened = [...flattened, ...result];
       }
@@ -32,10 +35,9 @@ export const getFlattenedPaths = (
   return flattened;
 };
 
-export function restructureFlattenedTreeItemsForAutocomplete(
-  items: Item[],
-  sep = ' / '
-) {
+export function restructureFlattenedTreeItemsForAutocomplete<
+  Item extends BasicItem<Item>
+>(items: Item[], sep = ' / ') {
   return {
     id: items[items.length - 1].id,
     pathLabel: items.map((item) => item.label).join(sep),
@@ -43,9 +45,9 @@ export function restructureFlattenedTreeItemsForAutocomplete(
   };
 }
 
-export function restructureFlattenedTreeDataForAutocomplete(
-  flattenedTreeData: Item[][]
-) {
+export function restructureFlattenedTreeDataForAutocomplete<
+  Item extends BasicItem<Item>
+>(flattenedTreeData: Item[][]) {
   return flattenedTreeData.map((items) =>
     restructureFlattenedTreeItemsForAutocomplete(items)
   );


### PR DESCRIPTION
## Purpose
Types need updating to work with uniprot website

## Approach
Make tree-select item extendable with generics

## Testing
N/A

## Stories
N/A

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
