### PR TITLE
2021 08 sliding panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@testing-library/jest-dom": "5.14.0",
     "@testing-library/react": "11.2.7",
     "@types/classnames": "2.3.1",
-    "@types/react-dom": "^17.0.7",
+    "@types/react-dom": "17.0.7",
     "@types/react-router-dom": "5.1.7",
     "@types/uuid": "8.3.0",
     "@typescript-eslint/eslint-plugin": "4.26.1",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@testing-library/jest-dom": "5.14.0",
     "@testing-library/react": "11.2.7",
     "@types/classnames": "2.3.1",
+    "@types/react-dom": "^17.0.7",
     "@types/react-router-dom": "5.1.7",
     "@types/uuid": "8.3.0",
     "@typescript-eslint/eslint-plugin": "4.26.1",

--- a/src/components/__tests__/sliding-panel.spec.tsx
+++ b/src/components/__tests__/sliding-panel.spec.tsx
@@ -5,8 +5,9 @@ import renderWithRouter from '../../testHelpers/renderWithRouter';
 import SlidingPanel from '../sliding-panel';
 
 describe('SlidingPanel component', () => {
-  test('should click outside', () => {
-    const onClose = jest.fn();
+  const onClose = jest.fn();
+
+  beforeEach(() => {
     renderWithRouter(
       <>
         <div data-testid="outside-component" />
@@ -15,7 +16,18 @@ describe('SlidingPanel component', () => {
         </SlidingPanel>
       </>
     );
+  });
+
+  afterEach(jest.clearAllMocks);
+
+  test('should click outside', () => {
     fireEvent.click(screen.getByTestId('outside-component'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  test('should not call onClose when mouse clicks inside', async () => {
+    const inside = screen.getByText('Sliding panel content');
+    fireEvent.click(inside);
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/components/__tests__/sliding-panel.spec.tsx
+++ b/src/components/__tests__/sliding-panel.spec.tsx
@@ -20,7 +20,7 @@ describe('SlidingPanel component', () => {
 
   afterEach(jest.clearAllMocks);
 
-  test('should click outside', () => {
+  test('should call onClose when mouse clicks outside', async () => {
     fireEvent.click(screen.getByTestId('outside-component'));
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/components/__tests__/sliding-panel.spec.tsx
+++ b/src/components/__tests__/sliding-panel.spec.tsx
@@ -1,13 +1,21 @@
+import { fireEvent, screen } from '@testing-library/react';
+
 import renderWithRouter from '../../testHelpers/renderWithRouter';
 
 import SlidingPanel from '../sliding-panel';
 
 describe('SlidingPanel component', () => {
-  test('should render', () => {
+  test('should click outside', () => {
     const onClose = jest.fn();
-    const { asFragment } = renderWithRouter(
-      <SlidingPanel onClose={onClose} position="left" />
+    renderWithRouter(
+      <>
+        <div data-testid="outside-component" />
+        <SlidingPanel onClose={onClose} position="left" title="Title">
+          Sliding panel content
+        </SlidingPanel>
+      </>
     );
-    expect(asFragment()).toMatchSnapshot();
+    fireEvent.click(screen.getByTestId('outside-component'));
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/__tests__/sliding-panel.spec.tsx
+++ b/src/components/__tests__/sliding-panel.spec.tsx
@@ -1,0 +1,13 @@
+import renderWithRouter from '../../testHelpers/renderWithRouter';
+
+import SlidingPanel from '../sliding-panel';
+
+describe('SlidingPanel component', () => {
+  test('should render', () => {
+    const onClose = jest.fn();
+    const { asFragment } = renderWithRouter(
+      <SlidingPanel onClose={onClose} position="left" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -41,6 +41,7 @@ export { default as Tile } from './tile';
 export { default as TreeSelect } from './tree-select';
 export { default as Window } from './window/window';
 export { WindowActionButton } from './window/window-buttons';
+export { default as SlidingPanel } from './sliding-panel';
 
 // Hooks
 export { default as useModal } from '../hooks/modal';

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -43,10 +43,6 @@ type SlidingPanelProps = {
    * Add a close button in the panel header
    */
   withCloseButton?: boolean;
-  /**
-   * Should the panel be scrollable if the content is taller than the panel?
-   */
-  yScrollable?: boolean;
   className?: string;
 } & (LRBelowHeader | TBSlidingPanel);
 
@@ -57,9 +53,8 @@ const SlidingPanel: FC<SlidingPanelProps> = ({
   size = 'medium',
   title,
   withCloseButton = false,
-  className,
-  yScrollable = false,
   arrowX,
+  className,
 }) => {
   const node = useRef<HTMLDivElement>(null);
 
@@ -91,7 +86,6 @@ const SlidingPanel: FC<SlidingPanelProps> = ({
         Number.isFinite(arrowX) && `sliding-panel--${position}--below-header`,
         className
       )}
-      style={{ overflowY: yScrollable ? 'auto' : 'initial' }}
       ref={node}
     >
       {(title || withCloseButton) && (

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -1,0 +1,70 @@
+import { FC, useRef, useEffect, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import cn from 'classnames';
+
+import { Button, CloseIcon } from './index';
+
+import '../styles/components/sliding-panel.scss';
+
+const SlidingPanel: FC<{
+  position: 'top' | 'bottom' | 'left' | 'right';
+  title?: ReactNode;
+  withClose?: boolean;
+  className?: string;
+  yScrollable?: boolean;
+  onClose: (arg: void) => void;
+}> = ({
+  children,
+  position,
+  title,
+  withClose = false,
+  className,
+  onClose,
+  yScrollable = false,
+}) => {
+  const node = useRef<HTMLDivElement>(null);
+
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (node?.current && !node.current.contains(e.target as Node)) {
+        e.stopPropagation();
+        e.preventDefault();
+        onCloseRef.current();
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside, true);
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  }, []);
+
+  return createPortal(
+    <div
+      data-testid="sliding-panel"
+      className={cn(`sliding-panel sliding-panel--${position}`, className)}
+      style={{ overflowY: yScrollable ? 'auto' : 'initial' }}
+      ref={node}
+    >
+      {(title || withClose) && (
+        <div className="sliding-panel__header">
+          {title && <h1 className="small">{title}</h1>}
+          {withClose && (
+            <div className="sliding-panel__header__buttons">
+              <Button variant="tertiary" onClick={() => onCloseRef.current()}>
+                <CloseIcon />
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+      <div className="sliding-panel__content">{children}</div>
+    </div>,
+    document.body
+  );
+};
+
+export default SlidingPanel;

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -12,7 +12,7 @@ type LRBelowHeader = {
    */
   position: 'left' | 'right';
   /**
-   * Horizontal position of the arrow. If the panel appears below the page header.
+   * Horizontal position of the arrow if the panel appears below the page header.
    * Also works as a flag to display the arrow and display below the header
    */
   arrowX?: number;

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -8,16 +8,19 @@ import '../styles/components/sliding-panel.scss';
 
 const SlidingPanel: FC<{
   position: 'top' | 'bottom' | 'left' | 'right';
+  size: 'small' | 'medium' | 'large' | 'full-screen';
   title?: ReactNode;
-  withClose?: boolean;
+  withCloseButton?: boolean;
   className?: string;
+  offset?: number;
   yScrollable?: boolean;
   onClose: (arg: void) => void;
 }> = ({
   children,
-  position,
+  position = 'left',
+  size = 'medium',
   title,
-  withClose = false,
+  withCloseButton = false,
   className,
   onClose,
   yScrollable = false,
@@ -45,14 +48,19 @@ const SlidingPanel: FC<{
   return createPortal(
     <div
       data-testid="sliding-panel"
-      className={cn(`sliding-panel sliding-panel--${position}`, className)}
+      className={cn(
+        'sliding-panel',
+        `sliding-panel--${position}`,
+        `sliding-panel--${position}--${size}`,
+        className
+      )}
       style={{ overflowY: yScrollable ? 'auto' : 'initial' }}
       ref={node}
     >
-      {(title || withClose) && (
+      {(title || withCloseButton) && (
         <div className="sliding-panel__header">
           {title && <h1 className="small">{title}</h1>}
-          {withClose && (
+          {withCloseButton && (
             <div className="sliding-panel__header__buttons">
               <Button variant="tertiary" onClick={() => onCloseRef.current()}>
                 <CloseIcon />

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -8,7 +8,7 @@ import '../styles/components/sliding-panel.scss';
 
 const SlidingPanel: FC<{
   position: 'top' | 'bottom' | 'left' | 'right';
-  size: 'small' | 'medium' | 'large' | 'full-screen';
+  size?: 'small' | 'medium' | 'large' | 'full-screen';
   title?: ReactNode;
   withCloseButton?: boolean;
   className?: string;

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -6,11 +6,27 @@ import { Button, CloseIcon } from './index';
 
 import '../styles/components/sliding-panel.scss';
 
-type SlidingPanelProps = {
+type LRBelowHeader = {
   /**
-   * Where the sliding panel will slide from
+   * Where the sliding panel should appear
    */
-  position?: 'top' | 'bottom' | 'left' | 'right';
+  position: 'left' | 'right';
+  /**
+   * Horizontal position of the arrow. If the panel appears below the page header.
+   * Also works as a flag to display the arrow and display below the header
+   */
+  arrowX?: number;
+};
+
+type TBSlidingPanel = {
+  /**
+   * Where the sliding panel should appear
+   */
+  position: 'top' | 'bottom';
+  arrowX?: never;
+};
+
+type SlidingPanelProps = {
   /**
    * What happens when close is triggered. Responsability of the user of the compoent
    */
@@ -31,27 +47,17 @@ type SlidingPanelProps = {
    * Should the panel be scrollable if the content is taller than the panel?
    */
   yScrollable?: boolean;
-  /**
-   * Should a 'left' or 'right' panel appear below the page header?
-   */
-  bellowHeader?: boolean;
-  /**
-   * Horizontal position of the arrow. If the panel appears below the page header.
-   * Also works as a flag to display the arrow.
-   */
-  arrowX?: number;
   className?: string;
-};
+} & (LRBelowHeader | TBSlidingPanel);
 
 const SlidingPanel: FC<SlidingPanelProps> = ({
   children,
   onClose,
-  position = 'left',
+  position,
   size = 'medium',
   title,
   withCloseButton = false,
   className,
-  bellowHeader = false,
   yScrollable = false,
   arrowX,
 }) => {
@@ -82,7 +88,7 @@ const SlidingPanel: FC<SlidingPanelProps> = ({
         'sliding-panel',
         `sliding-panel--${position}`,
         `sliding-panel--${position}--${size}`,
-        bellowHeader && `sliding-panel--${position}--bellow-header`,
+        Number.isFinite(arrowX) && `sliding-panel--${position}--below-header`,
         className
       )}
       style={{ overflowY: yScrollable ? 'auto' : 'initial' }}

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -98,7 +98,7 @@ const SlidingPanel: FC<SlidingPanelProps> = ({
               </Button>
             </div>
           )}
-          {arrowX && (
+          {Number.isFinite(arrowX) && (
             <div
               className="sliding-panel__header__arrow"
               style={{ left: arrowX }}

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -6,18 +6,44 @@ import { Button, CloseIcon } from './index';
 
 import '../styles/components/sliding-panel.scss';
 
-const SlidingPanel: FC<{
+type SlidingPanelProps = {
+  /**
+   * Where the sliding panel will slide from
+   */
   position?: 'top' | 'bottom' | 'left' | 'right';
+  /**
+   * What happens when close is triggered. Responsability of the user of the compoent
+   */
   onClose: (arg: void) => void;
+  /**
+   * Size of the panel once opened
+   */
   size?: 'small' | 'medium' | 'large' | 'full-screen';
+  /**
+   * Title of the panel
+   */
   title?: ReactNode;
+  /**
+   * Add a close button in the panel header
+   */
   withCloseButton?: boolean;
-  className?: string;
-  offset?: number;
+  /**
+   * Should the panel be scrollable if the content is taller than the panel?
+   */
   yScrollable?: boolean;
+  /**
+   * Should a 'left' or 'right' panel appear below the page header?
+   */
   bellowHeader?: boolean;
+  /**
+   * Horizontal position of the arrow. If the panel appears below the page header.
+   * Also works as a flag to display the arrow.
+   */
   arrowX?: number;
-}> = ({
+  className?: string;
+};
+
+const SlidingPanel: FC<SlidingPanelProps> = ({
   children,
   onClose,
   position = 'left',

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -14,6 +14,7 @@ const SlidingPanel: FC<{
   className?: string;
   offset?: number;
   yScrollable?: boolean;
+  bellowHeader?: boolean;
   onClose: (arg: void) => void;
 }> = ({
   children,
@@ -22,6 +23,7 @@ const SlidingPanel: FC<{
   title,
   withCloseButton = false,
   className,
+  bellowHeader = false,
   onClose,
   yScrollable = false,
 }) => {
@@ -52,6 +54,7 @@ const SlidingPanel: FC<{
         'sliding-panel',
         `sliding-panel--${position}`,
         `sliding-panel--${position}--${size}`,
+        bellowHeader && `sliding-panel--${position}--bellow-header`,
         className
       )}
       style={{ overflowY: yScrollable ? 'auto' : 'initial' }}

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -7,7 +7,8 @@ import { Button, CloseIcon } from './index';
 import '../styles/components/sliding-panel.scss';
 
 const SlidingPanel: FC<{
-  position: 'top' | 'bottom' | 'left' | 'right';
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  onClose: (arg: void) => void;
   size?: 'small' | 'medium' | 'large' | 'full-screen';
   title?: ReactNode;
   withCloseButton?: boolean;
@@ -15,17 +16,18 @@ const SlidingPanel: FC<{
   offset?: number;
   yScrollable?: boolean;
   bellowHeader?: boolean;
-  onClose: (arg: void) => void;
+  arrowX?: number;
 }> = ({
   children,
+  onClose,
   position = 'left',
   size = 'medium',
   title,
   withCloseButton = false,
   className,
   bellowHeader = false,
-  onClose,
   yScrollable = false,
+  arrowX,
 }) => {
   const node = useRef<HTMLDivElement>(null);
 
@@ -69,6 +71,12 @@ const SlidingPanel: FC<{
                 <CloseIcon />
               </Button>
             </div>
+          )}
+          {arrowX && (
+            <div
+              className="sliding-panel__header__arrow"
+              style={{ left: arrowX }}
+            />
           )}
         </div>
       )}

--- a/src/styles/common/_z-index.scss
+++ b/src/styles/common/_z-index.scss
@@ -1,3 +1,4 @@
 $z-index-low: 2000;
 $z-index-medium: 5000;
-$z-index-high:9000;
+$z-index-high: 9000;
+$z-index-highest: 10000;

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -62,6 +62,13 @@
         color: $colour-sky-white;
       }
     }
+    &__arrow {
+      position: absolute;
+      top: -1rem;
+      border-left: 1rem solid transparent;
+      border-right: 1rem solid transparent;
+      border-bottom: 1rem solid $colour-independence;
+    }
   }
 
   &__content {

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -40,6 +40,8 @@ $arrow-size: 1rem;
   border-radius: 0.2rem;
   padding: 0;
   position: fixed;
+  display: flex;
+  flex-direction: column;
   z-index: $z-index-highest;
   opacity: 1;
   margin: 0;

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -79,8 +79,24 @@
   &--top,
   &--bottom {
     width: 100vw;
-    height: 40vh;
     left: 0;
+  }
+
+  &--top--small,
+  &--bottom--small {
+    height: 20vh;
+  }
+  &--top--medium,
+  &--bottom--medium {
+    height: 40vh;
+  }
+  &--top--large,
+  &--bottom--large {
+    height: 60vh;
+  }
+  &--top--full-screen,
+  &--bottom--full-screen {
+    height: 100vh;
   }
 
   &--top {
@@ -96,8 +112,28 @@
   &--left,
   &--right {
     height: 100vh;
-    width: min(max(40vw, 55rem), calc(90vw));
     top: 0;
+  }
+
+  &--left--small,
+  &--right--small {
+    width: min(max(30vw, 22rem), calc(40vw));
+  }
+
+  &--left--medium,
+  &--right--medium {
+    // Values are eyeballed to fit the Query builder
+    width: min(max(40vw, 55rem), calc(90vw));
+  }
+
+  &--left--large,
+  &--right--large {
+    width: min(max(60vw, 77rem), calc(95vw));
+  }
+
+  &--left--full-screen,
+  &--right--full-screen {
+    width: 100vw;
   }
 
   &--left {

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -6,6 +6,8 @@
 // Note: this should be defined in franklin, currently defined in uniprot-website
 $top-header-margin: 70px;
 
+$arrow-size: 1rem;
+
 @keyframes slide-in-top {
   from {
     opacity: 0;
@@ -68,15 +70,17 @@ $top-header-margin: 70px;
     &__arrow {
       position: fixed;
       top: $top-header-margin;
-      margin-top: -1rem;
-      border-left: 1rem solid transparent;
-      border-right: 1rem solid transparent;
-      border-bottom: 1rem solid $colour-independence;
+      margin-top: -$arrow-size;
+      margin-left: -$arrow-size;
+      border-left: $arrow-size solid transparent;
+      border-right: $arrow-size solid transparent;
+      border-bottom: $arrow-size solid $colour-independence;
     }
   }
 
   &__content {
     padding: $global-padding;
+    overflow-y: auto;
   }
 
   &__button-row {

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -11,26 +11,26 @@ $arrow-size: 1rem;
 @keyframes slide-in-top {
   from {
     opacity: 0;
-    margin-top: -1000px;
+    margin-top: -65rem;
   }
 }
 
 @keyframes slide-in-right {
   from {
     opacity: 0;
-    margin-right: -1000px;
+    margin-right: -65rem;
   }
 }
 @keyframes slide-in-bottom {
   from {
     opacity: 0;
-    margin-bottom: -1000px;
+    margin-bottom: -65rem;
   }
 }
 @keyframes slide-in-left {
   from {
     opacity: 0;
-    margin-left: -1000px;
+    margin-left: -65rem;
   }
 }
 

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -115,6 +115,13 @@
     top: 0;
   }
 
+  &--left--bellow-header,
+  &--right--bellow-header {
+    top: 0;
+    margin-top: 70px; // Note: this should be a variable, currently defined in uniprot-website
+    height: calc(100vh - 70px);
+  }
+
   &--left--small,
   &--right--small {
     width: min(max(30vw, 22rem), calc(40vw));

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -136,7 +136,7 @@ $arrow-size: 1rem;
   &--right--below-header {
     top: 0;
     margin-top: $top-header-margin;
-    height: calc(100vh - $top-header-margin);
+    height: calc(100vh - #{$top-header-margin});
   }
 
   &--left--small,

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -122,8 +122,8 @@
     top: 0;
   }
 
-  &--left--bellow-header,
-  &--right--bellow-header {
+  &--left--below-header,
+  &--right--below-header {
     top: 0;
     margin-top: 70px; // Note: this should be a variable, currently defined in uniprot-website
     height: calc(100vh - 70px);

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -1,0 +1,112 @@
+@import '../settings';
+@import '../colours';
+@import '../mixins';
+@import '../common/z-index';
+
+@keyframes slide-in-top {
+  from {
+    opacity: 0;
+    margin-top: -1000px;
+  }
+}
+
+@keyframes slide-in-right {
+  from {
+    opacity: 0;
+    margin-right: -1000px;
+  }
+}
+@keyframes slide-in-bottom {
+  from {
+    opacity: 0;
+    margin-bottom: -1000px;
+  }
+}
+@keyframes slide-in-left {
+  from {
+    opacity: 0;
+    margin-left: -1000px;
+  }
+}
+
+.sliding-panel {
+  @include box-shadow(0.125rem);
+  background-color: $colour-sky-white;
+  border-radius: 0.2rem;
+  padding: 0;
+  position: fixed;
+  z-index: $z-index-highest;
+  opacity: 1;
+  margin: 0;
+
+  // animation on mount
+  animation-duration: 500ms;
+  animation-iteration-count: 1;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: backwards;
+
+  &__header {
+    background-color: $colour-independence;
+    padding: $global-padding/2 $global-padding;
+    color: $colour-sky-white;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    h1 {
+      color: $colour-sky-white;
+      margin-bottom: 0;
+    }
+    &__buttons {
+      button.tertiary {
+        margin: 0;
+        color: $colour-sky-white;
+      }
+    }
+  }
+
+  &__content {
+    padding: $global-padding;
+  }
+
+  &__button-row {
+    position: sticky;
+    display: flex;
+    justify-content: flex-end;
+    padding: $global-padding/2 0;
+    bottom: 0;
+  }
+
+  &--top,
+  &--bottom {
+    width: 100vw;
+    height: 40vh;
+    left: 0;
+  }
+
+  &--top {
+    top: 0;
+    animation-name: slide-in-top;
+  }
+
+  &--bottom {
+    bottom: 0;
+    animation-name: slide-in-bottom;
+  }
+
+  &--left,
+  &--right {
+    height: 100vh;
+    width: min(max(40vw, 55rem), calc(90vw));
+    top: 0;
+  }
+
+  &--left {
+    left: 0;
+    animation-name: slide-in-left;
+  }
+
+  &--right {
+    right: 0;
+    animation-name: slide-in-right;
+  }
+}

--- a/src/styles/components/sliding-panel.scss
+++ b/src/styles/components/sliding-panel.scss
@@ -3,6 +3,9 @@
 @import '../mixins';
 @import '../common/z-index';
 
+// Note: this should be defined in franklin, currently defined in uniprot-website
+$top-header-margin: 70px;
+
 @keyframes slide-in-top {
   from {
     opacity: 0;
@@ -63,8 +66,9 @@
       }
     }
     &__arrow {
-      position: absolute;
-      top: -1rem;
+      position: fixed;
+      top: $top-header-margin;
+      margin-top: -1rem;
       border-left: 1rem solid transparent;
       border-right: 1rem solid transparent;
       border-bottom: 1rem solid $colour-independence;
@@ -125,8 +129,8 @@
   &--left--below-header,
   &--right--below-header {
     top: 0;
-    margin-top: 70px; // Note: this should be a variable, currently defined in uniprot-website
-    height: calc(100vh - 70px);
+    margin-top: $top-header-margin;
+    height: calc(100vh - $top-header-margin);
   }
 
   &--left--small,

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -1,13 +1,8 @@
+import { useCallback, useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import {
-  boolean,
-  number,
-  select,
-  text,
-  withKnobs,
-} from '@storybook/addon-knobs';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { loremIpsum } from 'lorem-ipsum';
-import { SlidingPanel } from '../src/components';
+import { Button, SlidingPanel } from '../src/components';
 
 export default {
   title: 'Layout/Sliding Panel',
@@ -21,27 +16,72 @@ export default {
   },
 };
 
-export const slidingPanel = () => (
-  <SlidingPanel
-    title={text('Title', 'Title')}
-    position={select('Position', ['top', 'right', 'bottom', 'left'], 'left')}
-    size={select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium')}
-    withCloseButton={boolean('withCloseButton', false)}
-    onClose={action('closing')}
-  >
-    {loremIpsum({ count: 25 })}
-  </SlidingPanel>
-);
+const usePosition = () =>
+  select('Position', ['top', 'right', 'bottom', 'left'], 'left');
+const useTitle = () => text('Title', 'Title');
+const useSize = () =>
+  select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium');
+const useWithCloseButton = () => boolean('withCloseButton', false);
+const useWithArrow = () => boolean('withArrow', false);
 
-export const slidingPanelWithArrow = () => (
-  <SlidingPanel
-    title={text('Title', 'Title')}
-    position={select('Position', ['right', 'left'], 'left')}
-    size={select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium')}
-    withCloseButton={boolean('withCloseButton', false)}
-    onClose={action('closing')}
-    arrowX={number('arrowX', 20)}
-  >
-    {loremIpsum({ count: 25 })}
-  </SlidingPanel>
-);
+export const SlidingPanels = () => {
+  const [showPanel, setShowPanel] = useState(false);
+  const [arrowX, setArrowX] = useState();
+
+  const position = usePosition();
+  const title = useTitle();
+  const size = useSize();
+  const withCloseButton = useWithCloseButton();
+  const withArrow =
+    useWithArrow() && (position === 'left' || position === 'right');
+
+  const buttonRef = useCallback(
+    (node) => {
+      if (node) {
+        if ((withArrow && position === 'left') || position === 'right') {
+          const bcr = node.getBoundingClientRect();
+          setArrowX(bcr.x + bcr.width / 2);
+        }
+      }
+    },
+    [withArrow, position]
+  );
+
+  const onButtonClick = () => {
+    setShowPanel(true);
+  };
+
+  const onClose = () => {
+    setShowPanel(false);
+    action('onClose');
+  };
+
+  return (
+    <>
+      <Button
+        onClick={onButtonClick}
+        style={{
+          position: 'absolute',
+          top: '-2rem',
+          left: position === 'left' ? '1rem' : '',
+          right: position === 'right' ? '1rem' : '',
+        }}
+        ref={buttonRef}
+      >
+        Click me
+      </Button>
+      {showPanel && (
+        <SlidingPanel
+          title={title}
+          position={position}
+          size={size}
+          withCloseButton={withCloseButton}
+          onClose={onClose}
+          arrowX={arrowX}
+        >
+          {loremIpsum({ count: 25 })}
+        </SlidingPanel>
+      )}
+    </>
+  );
+};

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -1,5 +1,11 @@
 import { action } from '@storybook/addon-actions';
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
+import {
+  boolean,
+  number,
+  select,
+  text,
+  withKnobs,
+} from '@storybook/addon-knobs';
 import { loremIpsum } from 'lorem-ipsum';
 import { SlidingPanel } from '../src/components';
 
@@ -24,6 +30,7 @@ export const slidingPanel = () => (
     onClose={action('closing')}
     yScrollable={boolean('yScrollable', false)}
     bellowHeader={boolean('bellowHeader', false)}
+    arrowX={number('arrowX', 0)}
   >
     {loremIpsum()}
   </SlidingPanel>

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -28,7 +28,6 @@ export const slidingPanel = () => (
     size={select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium')}
     withCloseButton={boolean('withCloseButton', false)}
     onClose={action('closing')}
-    yScrollable={boolean('yScrollable', false)}
   >
     {loremIpsum({ count: 25 })}
   </SlidingPanel>
@@ -41,7 +40,6 @@ export const slidingPanelWithArrow = () => (
     size={select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium')}
     withCloseButton={boolean('withCloseButton', false)}
     onClose={action('closing')}
-    yScrollable={boolean('yScrollable', false)}
     arrowX={number('arrowX', 20)}
   >
     {loremIpsum({ count: 25 })}

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -1,0 +1,26 @@
+import { action } from '@storybook/addon-actions';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
+import { loremIpsum } from 'lorem-ipsum';
+import { SlidingPanel } from '../src/components';
+
+export default {
+  title: 'Layout/Sliding Panel',
+  decorators: [withKnobs()],
+  parameters: {
+    purposeFunction: {
+      purpose: '',
+      function: '',
+    },
+  },
+};
+
+export const slidingPanel = () => (
+  <SlidingPanel
+    title={text('Title', 'Title')}
+    position={select('Position', ['top', 'right', 'bottom', 'left'], 'left')}
+    withClose={boolean('withClose', false)}
+    onClose={action('closing')}
+  >
+    {loremIpsum()}
+  </SlidingPanel>
+);

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -30,7 +30,7 @@ export const slidingPanel = () => (
     onClose={action('closing')}
     yScrollable={boolean('yScrollable', false)}
   >
-    {loremIpsum()}
+    {loremIpsum({ count: 25 })}
   </SlidingPanel>
 );
 

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -8,8 +8,9 @@ export default {
   decorators: [withKnobs()],
   parameters: {
     purposeFunction: {
-      purpose: '',
-      function: '',
+      purpose:
+        'Display additional information or options without leaving the page',
+      function: 'Overlayed on top of the page, obfuscating part of the page.',
     },
   },
 };
@@ -18,8 +19,10 @@ export const slidingPanel = () => (
   <SlidingPanel
     title={text('Title', 'Title')}
     position={select('Position', ['top', 'right', 'bottom', 'left'], 'left')}
-    withClose={boolean('withClose', false)}
+    size={select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium')}
+    withCloseButton={boolean('withCloseButton', false)}
     onClose={action('closing')}
+    yScrollable={boolean('yScrollable', false)}
   >
     {loremIpsum()}
   </SlidingPanel>

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -23,6 +23,7 @@ export const slidingPanel = () => (
     withCloseButton={boolean('withCloseButton', false)}
     onClose={action('closing')}
     yScrollable={boolean('yScrollable', false)}
+    bellowHeader={boolean('bellowHeader', false)}
   >
     {loremIpsum()}
   </SlidingPanel>

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -18,33 +18,50 @@ export default {
 
 const usePosition = () =>
   select('Position', ['top', 'right', 'bottom', 'left'], 'left');
+const usePositionLR = () => select('Position', ['right', 'left'], 'left');
+
 const useTitle = () => text('Title', 'Title');
 const useSize = () =>
   select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium');
 const useWithCloseButton = () => boolean('withCloseButton', false);
-const useWithArrow = () => boolean('withArrow', false);
 
 export const SlidingPanels = () => {
+  const title = useTitle();
+  const position = usePosition();
+  const size = useSize();
+  const withCloseButton = useWithCloseButton();
+
+  return (
+    <SlidingPanel
+      title={title}
+      position={position}
+      size={size}
+      withCloseButton={withCloseButton}
+      onClose={() => action('Closing')}
+    >
+      {loremIpsum({ count: 25 })}
+    </SlidingPanel>
+  );
+};
+
+export const SlidingPanelsWithArrow = () => {
   const [showPanel, setShowPanel] = useState(false);
   const [arrowX, setArrowX] = useState();
 
-  const position = usePosition();
+  const position = usePositionLR();
   const title = useTitle();
   const size = useSize();
   const withCloseButton = useWithCloseButton();
-  const withArrow =
-    useWithArrow() && (position === 'left' || position === 'right');
 
   const buttonRef = useCallback(
     (node) => {
       if (node) {
-        if ((withArrow && position === 'left') || position === 'right') {
-          const bcr = node.getBoundingClientRect();
-          setArrowX(bcr.x + bcr.width / 2);
-        }
+        const bcr = node.getBoundingClientRect();
+        setArrowX(bcr.x + bcr.width / 2);
       }
     },
-    [withArrow, position]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [position]
   );
 
   const onButtonClick = () => {

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -44,6 +44,6 @@ export const slidingPanelWithArrow = () => (
     yScrollable={boolean('yScrollable', false)}
     arrowX={number('arrowX', 20)}
   >
-    {loremIpsum()}
+    {loremIpsum({ count: 25 })}
   </SlidingPanel>
 );

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -29,8 +29,20 @@ export const slidingPanel = () => (
     withCloseButton={boolean('withCloseButton', false)}
     onClose={action('closing')}
     yScrollable={boolean('yScrollable', false)}
-    bellowHeader={boolean('bellowHeader', false)}
-    arrowX={number('arrowX', 0)}
+  >
+    {loremIpsum()}
+  </SlidingPanel>
+);
+
+export const slidingPanelWithArrow = () => (
+  <SlidingPanel
+    title={text('Title', 'Title')}
+    position={select('Position', ['right', 'left'], 'left')}
+    size={select('Size', ['small', 'medium', 'large', 'full-screen'], 'medium')}
+    withCloseButton={boolean('withCloseButton', false)}
+    onClose={action('closing')}
+    yScrollable={boolean('yScrollable', false)}
+    arrowX={number('arrowX', 20)}
   >
     {loremIpsum()}
   </SlidingPanel>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,7 +2948,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^17.0.7":
+"@types/react-dom@17.0.7":
   version "17.0.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.7.tgz#b8ee15ead9e5d6c2c858b44949fdf2ebe5212232"
   integrity sha512-Wd5xvZRlccOrCTej8jZkoFZuZRKHzanDDv1xglI33oBNFMWrqOSzrvWFw7ngSiZjrpJAzPKFtX7JvuXpkNmQHA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,6 +2948,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@^17.0.7":
+  version "17.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.7.tgz#b8ee15ead9e5d6c2c858b44949fdf2ebe5212232"
+  integrity sha512-Wd5xvZRlccOrCTej8jZkoFZuZRKHzanDDv1xglI33oBNFMWrqOSzrvWFw7ngSiZjrpJAzPKFtX7JvuXpkNmQHA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-router-dom@5.1.7":
   version "5.1.7"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.7.tgz#a126d9ea76079ffbbdb0d9225073eb5797ab7271"


### PR DESCRIPTION
## Purpose
Move the SlidingPanel component out of the website. Extend to have:
- multiple sizes
- option to show below the page header, and to add an arrow at a position specified by the parent
- an optional close button

## Approach
Add props and conditional styles.

## Testing
Test the outside click

## Stories
Created a new story

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
