### PR TITLE
2021 08 tree select bugs

### DIFF
--- a/src/components/dropdown-button.tsx
+++ b/src/components/dropdown-button.tsx
@@ -98,9 +98,10 @@ const DropdownButton = ({
   return (
     <div
       className="dropdown-container"
-      onBlur={(e) =>
-        setShowMenu(e.currentTarget.contains(e.relatedTarget as Node))
-      }
+      // TODO: uncomment when Safari resolves bug: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus
+      // onBlur={(e) =>
+      //   setShowMenu(e.currentTarget.contains(e.relatedTarget as Node))
+      // }
       onPointerEnter={openOnHover ? () => setShowMenu(true) : undefined}
       onPointerLeave={openOnHover ? () => setShowMenu(false) : undefined}
     >

--- a/src/styles/components/dropdown.scss
+++ b/src/styles/components/dropdown.scss
@@ -75,6 +75,7 @@
           border: none;
           padding-right: 1rem;
           text-decoration: none;
+          white-space: nowrap;
 
           &:hover {
             @extend .hover;

--- a/src/styles/components/tree-select.scss
+++ b/src/styles/components/tree-select.scss
@@ -13,7 +13,6 @@
       position: relative;
       top: 0.4rem;
       float: right;
-      margin-left: 1rem;
     }
 
     &.branch {

--- a/stories/Buttons.stories.tsx
+++ b/stories/Buttons.stories.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties } from 'react';
 import { withKnobs, select, boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import { Button, DownloadIcon } from '../src/components';
 
@@ -26,15 +27,25 @@ export const Buttons = () => {
   return (
     <div style={{ '--main-button-color': color } as CSSProperties}>
       <div>
-        <Button disabled={disabled}>Primary</Button>
+        <Button disabled={disabled} onClick={action('onClick')}>
+          Primary
+        </Button>
       </div>
       <div>
-        <Button variant="secondary" disabled={disabled}>
+        <Button
+          variant="secondary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
           Secondary
         </Button>
       </div>
       <div>
-        <Button variant="tertiary" disabled={disabled}>
+        <Button
+          variant="tertiary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
           Tertiary
         </Button>
       </div>
@@ -48,40 +59,82 @@ export const ButtonGroups = () => {
   return (
     <div style={{ '--main-button-color': color } as CSSProperties}>
       <div className="button-group">
-        <button className="button tertiary" type="button">
+        <button
+          className="button tertiary"
+          type="button"
+          onClick={action('onClick')}
+        >
           One
         </button>
-        <button className="button tertiary" type="button">
+        <button
+          className="button tertiary"
+          type="button"
+          onClick={action('onClick')}
+        >
           Two
         </button>
-        <button className="button tertiary" type="button">
+        <button
+          className="button tertiary"
+          type="button"
+          onClick={action('onClick')}
+        >
           Three
         </button>
       </div>
       <div className="button-group">
-        <Button disabled={disabled}>One</Button>
-        <Button disabled={disabled}>Two</Button>
-        <Button disabled={disabled}>Three</Button>
-      </div>
-      <div className="button-group">
-        <Button variant="secondary" disabled={disabled}>
+        <Button disabled={disabled} onClick={action('onClick')}>
           One
         </Button>
-        <Button variant="secondary" disabled={disabled}>
+        <Button disabled={disabled} onClick={action('onClick')}>
           Two
         </Button>
-        <Button variant="secondary" disabled={disabled}>
+        <Button disabled={disabled} onClick={action('onClick')}>
           Three
         </Button>
       </div>
       <div className="button-group">
-        <Button variant="tertiary" disabled={disabled}>
+        <Button
+          variant="secondary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
           One
         </Button>
-        <Button variant="tertiary" disabled={disabled}>
+        <Button
+          variant="secondary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
           Two
         </Button>
-        <Button variant="tertiary" disabled={disabled}>
+        <Button
+          variant="secondary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
+          Three
+        </Button>
+      </div>
+      <div className="button-group">
+        <Button
+          variant="tertiary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
+          One
+        </Button>
+        <Button
+          variant="tertiary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
+          Two
+        </Button>
+        <Button
+          variant="tertiary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
           Three
         </Button>
       </div>
@@ -95,19 +148,27 @@ export const WithIcon = () => {
   return (
     <div style={{ '--main-button-color': color } as CSSProperties}>
       <div>
-        <Button disabled={disabled}>
+        <Button disabled={disabled} onClick={action('onClick')}>
           <DownloadIcon />
           Primary
         </Button>
       </div>
       <div>
-        <Button variant="secondary" disabled={disabled}>
+        <Button
+          variant="secondary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
           <DownloadIcon />
           Secondary
         </Button>
       </div>
       <div>
-        <Button variant="tertiary" disabled={disabled}>
+        <Button
+          variant="tertiary"
+          disabled={disabled}
+          onClick={action('onClick')}
+        >
           <DownloadIcon />
           Tertiary
         </Button>


### PR DESCRIPTION
## Purpose
A few bugs seen with the TreeSelect:

1.  In Safari and Firefox (couldn't reproduce myself with FF89), when clicking on a TreeSelect parent element, the containing dropdown menu closes instead of showing that element's children ([jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-25862))
2. In Safari, when selecting an autocomplete item the click isn't registered
3. In all browsers, the tree node arrow sometimes appears on the next line

## Approach

1. 1 & 2: Comment out `onBlur` at line 101 of dropdown-button. You can see the difference in behaviour between Chrome and Safari with the following code:
```
      onBlur={(e) => {
        console.log(
          e.currentTarget,
          e.relatedTarget,
          e.currentTarget.contains(e.relatedTarget as Node)
        );
      }}
```
As the comment states there is [an open bug report](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus) so not sure how else to deal with it at this present time? I can't see the effect of commenting out `onBlur` aside from eliminating the observed bugs.

2. CSS updates

## Testing
None

## Stories
I added `onClick` actions to the button in the process of my debugging but thought might as well leave these in.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
