### PR TITLE
close panel when changing path, and not when clicking within

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
         "aspects": ["noHref", "invalidHref", "preferButton"]
       }
     ],
+    "no-restricted-syntax": "off",
     "no-shadow": "off",
     "no-use-before-define": "off",
     "react/no-did-update-set-state": "off",

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -50,7 +50,6 @@ export const parse = (
   const customParsed: CustomParsedQuery = parsed;
   customParsed[queryStringKey] = {};
   const field = customParsed[queryStringKey] as CustomQueryValue;
-  // eslint-disable-next-line no-restricted-syntax
   for (const [name, value] of facets) {
     if (!field[name]) {
       field[name] = new Set();

--- a/src/components/in-page-nav.jsx
+++ b/src/components/in-page-nav.jsx
@@ -31,7 +31,6 @@ const InPageNav = ({ sections, rootElement }) => {
 
     const io = new window.IntersectionObserver(
       (entries) => {
-        // eslint-disable-next-line no-restricted-syntax
         for (const entry of entries) {
           // update the visibility map
           visibilityMap.set(entry.target, {
@@ -42,7 +41,6 @@ const InPageNav = ({ sections, rootElement }) => {
 
         let mostVisible;
         let highestVisibility = 0;
-        // eslint-disable-next-line no-restricted-syntax
         for (const [element, { height, ratio }] of visibilityMap.entries()) {
           // find the most visible element
           if (highestVisibility < height) {
@@ -78,7 +76,6 @@ const InPageNav = ({ sections, rootElement }) => {
           .map(({ id }) => document.querySelector(`#${id}`))
           .filter(Boolean);
 
-        // eslint-disable-next-line no-restricted-syntax
         for (const element of elements) {
           io.observe(element);
           visibilityMap.set(element, 0);

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -1,5 +1,6 @@
 import { FC, useRef, useEffect, ReactNode, HTMLAttributes } from 'react';
 import { createPortal } from 'react-dom';
+import { useLocation } from 'react-router-dom';
 import cn from 'classnames';
 
 import { Button, CloseIcon } from './index';
@@ -63,11 +64,20 @@ const SlidingPanel: FC<
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
+  // Handle closing the sliding panel when there's a click outside
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (node?.current && !node.current.contains(e.target as Node)) {
-        onCloseRef.current();
+      // loop through all the currently opened panels
+      for (const panel of document.querySelectorAll<HTMLDivElement>(
+        '.sliding-panel'
+      )) {
+        // if the click event was within one, bail out of the whole function
+        if (panel.contains(e.target as Node)) {
+          return;
+        }
       }
+      // If none of the panels contains the target, close the panel
+      onCloseRef.current();
     };
 
     document.addEventListener('click', handleClickOutside, true);
@@ -75,6 +85,18 @@ const SlidingPanel: FC<
       document.removeEventListener('click', handleClickOutside, true);
     };
   }, []);
+
+  // Handle closing the sliding panel when there's a path change
+  const { pathname } = useLocation();
+  const firstTime = useRef(true);
+  useEffect(() => {
+    if (firstTime.current) {
+      firstTime.current = false;
+    } else {
+      onCloseRef.current();
+    }
+    // keep pathname below, this is to trigger the effect when it changes
+  }, [pathname]);
 
   return createPortal(
     <div

--- a/src/sequence-utils/index.js
+++ b/src/sequence-utils/index.js
@@ -10,7 +10,6 @@ export function formatFASTA(fasta, chunkSize = 10, chunksPerLine = 6) {
 
   let header = '';
   let sequence = '';
-  // eslint-disable-next-line no-restricted-syntax
   for (const line of fasta.split('\n')) {
     const trimmedLine = line.trim();
     if (commentLineRE.test(trimmedLine)) {

--- a/src/sequence-utils/sequence-processor.js
+++ b/src/sequence-utils/sequence-processor.js
@@ -10,15 +10,14 @@ const getNewSequenceObject = () => ({
   sequence: '',
 });
 
-const validate = sequenceObject => {
+const validate = (sequenceObject) => {
   const validation = sequenceValidator(sequenceObject.sequence);
   return { ...validation, ...sequenceObject };
 };
 
-const sequenceProcessor = rawText => {
+const sequenceProcessor = (rawText) => {
   const sequences = [];
   let currentSequence = getNewSequenceObject();
-  // eslint-disable-next-line no-restricted-syntax
   for (const line of rawText.split('\n')) {
     // for each line
 

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { loremIpsum } from 'lorem-ipsum';
+
 import { Button, SlidingPanel } from '../src/components';
 
 export default {
@@ -97,6 +98,65 @@ export const SlidingPanelsWithArrow = () => {
           arrowX={arrowX}
         >
           {loremIpsum({ count: 25 })}
+        </SlidingPanel>
+      )}
+    </>
+  );
+};
+
+export const SlidingPanelInSlidingPanel = () => {
+  const [showPanel, setShowPanel] = useState(false);
+  const [showPanel2, setShowPanel2] = useState(false);
+
+  const position = usePositionLR();
+  const title = useTitle();
+  const size = useSize();
+  const withCloseButton = useWithCloseButton();
+
+  return (
+    <>
+      <Button
+        onClick={() => setShowPanel(true)}
+        style={{
+          position: 'absolute',
+          top: '-2rem',
+          left: position === 'left' ? '1rem' : '',
+          right: position === 'right' ? '1rem' : '',
+        }}
+      >
+        Click me
+      </Button>
+      {showPanel && (
+        <SlidingPanel
+          title={`Sliding panel 1: ${title}`}
+          position={position}
+          size={size}
+          withCloseButton={withCloseButton}
+          onClose={() => {
+            setShowPanel(false);
+            setShowPanel2(false);
+            action('onClose 1');
+          }}
+        >
+          <>
+            <Button onClick={() => setShowPanel2(true)}>Click me too</Button>
+            <br />
+            {loremIpsum({ count: 25 })}
+            {showPanel2 && (
+              <SlidingPanel
+                title={`Sliding panel 2: ${title}`}
+                position={position}
+                size={size}
+                withCloseButton={withCloseButton}
+                onClose={() => {
+                  setShowPanel2(false);
+                  action('onClose 2');
+                }}
+              >
+                {loremIpsum({ count: 25 })}
+              </SlidingPanel>
+            )}
+          </>
         </SlidingPanel>
       )}
     </>


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-26382
https://www.ebi.ac.uk/panda/jira/browse/TRM-26294

## Approach
 - For the click within an follow-up sliding panel:
   - For all clicks on the page, detect if it is within *a* panel, any panel, and don't close any open panel in this case
 - For the close on path change:
   - Copy current logic from uniprot-website
   - Note that this logic will need to be removed from uniprot-website whenever the next version of franklin is added

## Testing
One more story

## Stories
Silding Panel story

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
