### PR TITLE
Release with otp

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:unit": "jest --coverage",
     "test-watch": "jest --watch",
     "prerelease": "yarn test && yarn build",
-    "release": "yarn publish && git push --follow-tags origin main",
+    "release": "./release.sh",
     "start": "start-storybook -p 6006 -s ./assets",
     "build-storybook": "build-storybook -c .storybook -o .out -s ./assets",
     "prepare": "husky install"

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 echo -n "Enter npm one-time password (OTP): "
 read OTP 
-yarn publish --otp=$OTP
+yarn publish --otp=$OTP || exit 1
 git push --follow-tags origin main

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+echo -n "Enter npm one-time password (OTP): "
+read OTP 
+yarn publish --otp=$OTP
+git push --follow-tags origin main


### PR DESCRIPTION
Was having issues with publishing before realising I had to append `--opt` to the `yarn publish` command. Created a script to make this more obvious in the future.