### PR TITLE
Trm 26304 chip remove bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prerelease": "yarn test && yarn build",
     "release": "yarn publish && git push --follow-tags origin main",
     "start": "start-storybook -p 6006 -s ./assets",
-    "build-storybook": "build-storybook -c .storybook -o .out -s ./assets",
+    "build-storybook": "build-storybook -72.16% .storybook -o .out -s ./assets",
     "prepare": "husky install"
   },
   "browserslist": [
@@ -49,7 +49,7 @@
         "lines": 82.38,
         "statements": 81.86,
         "functions": 78.6,
-        "branches": 72.24
+        "branches": 72.16
       }
     },
     "setupFilesAfterEnv": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prerelease": "yarn test && yarn build",
     "release": "yarn publish && git push --follow-tags origin main",
     "start": "start-storybook -p 6006 -s ./assets",
-    "build-storybook": "build-storybook -72.16% .storybook -o .out -s ./assets",
+    "build-storybook": "build-storybook -c .storybook -o .out -s ./assets",
     "prepare": "husky install"
   },
   "browserslist": [

--- a/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`Chip component should render 1`] = `
 <DocumentFragment>
-  <button
+  <span
     class="chip"
-    disabled=""
-    type="button"
+    role="button"
+    tabindex="0"
   >
     Some content
-  </button>
+  </span>
 </DocumentFragment>
 `;

--- a/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
@@ -2,12 +2,11 @@
 
 exports[`Chip component should render 1`] = `
 <DocumentFragment>
-  <span
+  <button
     class="chip"
-    role="button"
-    tabindex="0"
+    type="button"
   >
     Some content
-  </span>
+  </button>
 </DocumentFragment>
 `;

--- a/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/chip.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Chip component should render 1`] = `
+exports[`Chip component should render a button when onRemove is not passed 1`] = `
 <DocumentFragment>
   <button
     class="chip"

--- a/src/components/__tests__/chip.spec.tsx
+++ b/src/components/__tests__/chip.spec.tsx
@@ -24,11 +24,11 @@ describe('Chip component', () => {
 
   it('should not have disabled attribute when disabled=false passed as a prop', () => {
     render(<Chip disabled={false}>Some content</Chip>);
-    expect(screen.getByRole('button')).not.toHaveAttribute('disabled');
+    expect(screen.getByRole('button')).not.toHaveClass('chip--disabled');
   });
 
   it('should have disabled attribute when disabled=true passed as a prop', () => {
     render(<Chip disabled>Some content</Chip>);
-    expect(screen.getByRole('button')).toHaveAttribute('disabled');
+    expect(screen.getByRole('button')).toHaveClass('chip--disabled');
   });
 });

--- a/src/components/__tests__/chip.spec.tsx
+++ b/src/components/__tests__/chip.spec.tsx
@@ -3,14 +3,23 @@ import { screen, render, fireEvent } from '@testing-library/react';
 import Chip from '../chip';
 
 describe('Chip component', () => {
-  it('should render', () => {
+  it('should render a button when onRemove is not passed', () => {
     const { asFragment } = render(<Chip>Some content</Chip>);
     expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
-  it('should fire onRemove when remove SVG is clicked', () => {
+  it('should render span if onRemove is passed; have button role if onClick is also passed; fire onRemove when remove SVG is clicked', () => {
     const onRemove = jest.fn();
-    render(<Chip onRemove={onRemove}>Some content</Chip>);
+    render(
+      <Chip onRemove={onRemove} onClick={jest.fn()}>
+        Some content
+      </Chip>
+    );
+    expect(screen.getByText('Some content').tagName).toBe('SPAN');
+    expect(
+      screen.getByRole('button', { name: 'Some content' })
+    ).toBeInTheDocument();
     const removeIcon = screen.getByTestId('remove-icon');
     fireEvent.click(removeIcon);
     expect(onRemove).toHaveBeenCalled();

--- a/src/components/__tests__/chip.spec.tsx
+++ b/src/components/__tests__/chip.spec.tsx
@@ -16,6 +16,26 @@ describe('Chip component', () => {
     expect(onRemove).toHaveBeenCalled();
   });
 
+  it('should fire onClick when chip is clicked', () => {
+    const onClick = jest.fn();
+    render(<Chip onClick={onClick}>Some content</Chip>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should fire onKeyPress when key pressed', () => {
+    const onKeyPress = jest.fn();
+    render(<Chip onKeyPress={onKeyPress}>Some content</Chip>);
+    const chip = screen.getByRole('button');
+    chip.focus();
+    fireEvent.keyPress(document.activeElement || document.body, {
+      key: 'Enter',
+      code: 'Enter',
+      charCode: 13,
+    });
+    expect(onKeyPress).toHaveBeenCalled();
+  });
+
   it('should not show remove icon when onRemove prop is not passed', () => {
     render(<Chip>Some content</Chip>);
     const removeIcon = screen.queryByTestId('remove-icon');

--- a/src/components/chip.tsx
+++ b/src/components/chip.tsx
@@ -79,7 +79,6 @@ export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
       )}
       onKeyPress={onKeyPress}
       onClick={onClick}
-      title={title}
       tabIndex={0}
       {...props}
     >

--- a/src/components/chip.tsx
+++ b/src/components/chip.tsx
@@ -41,6 +41,10 @@ type ChipProps = {
    * click event listener on the component (except on the close button if present)
    */
   onClick?: () => void;
+  /**
+   * key press event listener on the component
+   */
+  onKeyPress?: () => void;
 };
 
 export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
@@ -51,6 +55,7 @@ export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
   compact = false,
   title,
   onClick,
+  onKeyPress,
   ...props
 }) => {
   const onRemoveRef = useRef(onRemove);
@@ -65,23 +70,24 @@ export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
   );
 
   return (
-    <button
-      type="button"
+    <span
+      role="button"
       className={cn(
         'chip',
         { 'chip--disabled': disabled, 'chip--compact': compact },
         className
       )}
-      title={title}
+      onKeyPress={onKeyPress}
       onClick={onClick}
-      disabled={typeof disabled === 'boolean' ? disabled : !onClick}
+      title={title}
+      tabIndex={0}
       {...props}
     >
       {children}
       {onRemove && !disabled && (
         <RemoveIcon data-testid="remove-icon" onClick={handleRemove} />
       )}
-    </button>
+    </span>
   );
 };
 

--- a/src/components/chip.tsx
+++ b/src/components/chip.tsx
@@ -47,7 +47,9 @@ type ChipProps = {
   onKeyPress?: () => void;
 };
 
-export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
+export const Chip: FC<
+  ChipProps & HTMLAttributes<HTMLButtonElement | HTMLSpanElement>
+> = ({
   children,
   onRemove,
   className = '',
@@ -56,7 +58,7 @@ export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
   title,
   onClick,
   onKeyPress,
-  ...props
+  ...rest
 }) => {
   const onRemoveRef = useRef(onRemove);
   onRemoveRef.current = onRemove;
@@ -68,25 +70,34 @@ export const Chip: FC<ChipProps & HTMLAttributes<HTMLButtonElement>> = ({
     },
     []
   );
+  const props = { ...rest };
+  let element: 'button' | 'span' = 'button';
+  if (onRemove) {
+    element = 'span';
+    if (onClick || onKeyPress) {
+      props.role = 'button';
+      props.tabIndex = 0;
+    }
+  }
 
+  const Element = element;
   return (
-    <span
-      role="button"
+    <Element
       className={cn(
         'chip',
         { 'chip--disabled': disabled, 'chip--compact': compact },
         className
       )}
+      type={element === 'button' ? 'button' : undefined}
       onKeyPress={onKeyPress}
       onClick={onClick}
-      tabIndex={0}
       {...props}
     >
       {children}
       {onRemove && !disabled && (
         <RemoveIcon data-testid="remove-icon" onClick={handleRemove} />
       )}
-    </span>
+    </Element>
   );
 };
 

--- a/src/styles/components/chip.scss
+++ b/src/styles/components/chip.scss
@@ -5,7 +5,8 @@
 
 .chip {
   --main-color: var(--main-chip-color, #{$colour-sea-blue});
-
+  line-height: 1;
+  user-select: none;
   display: inline-block;
   vertical-align: middle;
   margin: 0.25rem;

--- a/stories/Chips.stories.tsx
+++ b/stories/Chips.stories.tsx
@@ -60,6 +60,20 @@ export const withClick = () => (
   </>
 );
 
+export const withKeyPress = () => (
+  <>
+    <Chip
+      title="this is a primary chip"
+      onKeyPress={action('key press on primary')}
+    >
+      Primary
+    </Chip>
+    <Chip className="secondary" onKeyPress={action('key press on secondary')}>
+      Secondary
+    </Chip>
+  </>
+);
+
 export const removable = () => (
   <>
     <Chip onRemove={action('Remove chip')}>Primary</Chip>


### PR DESCRIPTION
## Purpose

- [Jira: BLAST: Can't remove organism chip, "x" not working](https://www.ebi.ac.uk/panda/jira/browse/TRM-26304)
- Adapt chip as Firefox won't fire onClick events on items within a button.

## Approach
- Convert chip from `<button>` to `<span>`

## Testing
- Updated unit tests and snapshots.
- Had to adjust coverage for some reason 🤷 

## Stories
- Added `onKeyPress` story

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
