### PR TITLE
Cache tabs

### DIFF
--- a/src/components/__tests__/tabs.spec.tsx
+++ b/src/components/__tests__/tabs.spec.tsx
@@ -84,4 +84,23 @@ describe('Tabs', () => {
     expect(content).not.toHaveTextContent('blah-1');
     expect(content).toHaveTextContent('blaher');
   });
+
+  test('should keep cached tab in document but not visible if not active', () => {
+    render(
+      <Tabs>
+        <Tab id="a" title={<div>Title 1</div>}>
+          blah-1
+        </Tab>
+        <Tab id="b" cache title="Title 2">
+          blaher
+        </Tab>
+        <Tab id="c" title="Title 3" />
+      </Tabs>
+    );
+    // First tab is active so as usual
+    expect(screen.queryByTestId('tab-content')).toHaveTextContent('blah-1');
+    // Second tab is inactive and cached so it should be in the document but not visible
+    expect(screen.queryByText('blaher')).toBeInTheDocument();
+    expect(screen.queryByText('blaher')).not.toBeVisible();
+  });
 });

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -30,6 +30,10 @@ type TabProps = {
    * Choose that tab as the default to be displayed
    */
   defaultSelected?: boolean;
+  /**
+   * Option to render and hide tab (with style:hidden) rather than remove from the DOM
+   */
+  cache?: boolean;
 } & Except<HTMLAttributes<HTMLDivElement>, 'title' | 'id'>;
 
 // This is just a configuration component, it doesn't need to render anything as
@@ -113,7 +117,23 @@ export const Tabs = ({ children, active, className, ...props }: TabsProps) => {
   if (!selectedTab) {
     throw new Error(`Could not find a tab with the id: "${selectedState}"`);
   }
-  const content = selectedTab.children;
+
+  let content;
+  const hasCacheTab = tabs.some(({ cache }) => cache);
+  if (hasCacheTab) {
+    content = tabs.map((tab) => {
+      const selected = tab.id === selectedTab.id;
+      return (
+        (tab.cache || selected) && (
+          <div key={tab.id} style={{ display: selected ? 'block' : 'none' }}>
+            {tab.children}
+          </div>
+        )
+      );
+    });
+  } else {
+    content = selectedTab.children;
+  }
 
   let unmanagedProps = {};
   // add event listeners in case this is not an externally managed component
@@ -135,6 +155,7 @@ export const Tabs = ({ children, active, className, ...props }: TabsProps) => {
             className, // eslint-disable-line no-shadow
             children: _,
             defaultSelected: __,
+            cache: ___,
             ...props // eslint-disable-line no-shadow
           }) => (
             <div

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -31,7 +31,7 @@ type TabProps = {
    */
   defaultSelected?: boolean;
   /**
-   * Option to render and hide tab (with style:hidden) rather than remove from the DOM
+   * Option to render and hide tab (display:none) rather than remove from the DOM
    */
   cache?: boolean;
 } & Except<HTMLAttributes<HTMLDivElement>, 'title' | 'id'>;

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -108,6 +108,7 @@ export const managedTabs = () => <ManagedTabs />;
 export const cachedTabs = () => (
   <Tabs>
     <Tab
+      cache
       title={
         <>
           Title 1
@@ -118,7 +119,6 @@ export const cachedTabs = () => (
           />
         </>
       }
-      cache
     >
       {loremIpsum({ count: 2 })}
     </Tab>

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -104,3 +104,27 @@ const ManagedTabs = () => {
 };
 
 export const managedTabs = () => <ManagedTabs />;
+
+export const cachedTabs = () => (
+  <Tabs>
+    <Tab
+      title={
+        <>
+          Title 1
+          <ConfigureIcon
+            style={{ verticalAlign: 'text-top' }}
+            width={16}
+            height={16}
+          />
+        </>
+      }
+      cache
+    >
+      {loremIpsum({ count: 2 })}
+    </Tab>
+    <Tab title="Title 2">{loremIpsum({ count: 2 })}</Tab>
+    <Tab cache title="Title 3">
+      {loremIpsum({ count: 2 })}
+    </Tab>
+  </Tabs>
+);


### PR DESCRIPTION
## Purpose
As part of adding the GO tab to the sub-cellular visualisation section of an entry page ([jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-25568) | [PR](https://github.com/ebi-uniprot/uniprot-website/pull/427)) there is a need to keep the tab content in the document when not active.

## Approach
- Consumer can add the prop `cache` to the `Tab` which needs to always be in the document
- When `Tabs` returns content it maps through and tabs and applies `display:none` to those inactive, cache tabs
- If no `Tab` has the `cache` prop the standard behaviour of only rendering the active tab is used

## Testing
- Added unit test

## Stories
- Added story

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiable through knobs?