### PR TITLE
Sliding panel changes

### DIFF
--- a/src/components/__tests__/sliding-panel.spec.tsx
+++ b/src/components/__tests__/sliding-panel.spec.tsx
@@ -17,7 +17,7 @@ describe('SlidingPanel component', () => {
       </>
     );
     fireEvent.click(screen.getByText('Sliding panel content'));
-    await waitFor(() => sleep(200));
+    await sleep(200);
     fireEvent.click(screen.getByTestId('outside-component'));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });


### PR DESCRIPTION
## Purpose
To handle the use case of closing it if the button used to open it is clicked again. https://www.ebi.ac.uk/panda/jira/browse/TRM-26450

## Approach
 - Wait one frame before closing it, in order to flush the current event listeners, because closing is the last thing we'll want  to do
 - Better focus management for accessibility: Move focus in the first focusable element within when opening the panel, and restore it to where it was previously when closing it.

## Testing
Updated tests, added a test to check the focus management (improved coverage)

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
