### PR TITLE
2021 11 autocomplete

### DIFF
--- a/src/components/__tests__/__snapshots__/autocomplete.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/autocomplete.spec.tsx.snap
@@ -36,7 +36,7 @@ exports[`Autocomplete component should render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Autocomplete component should render with props: showDropdownUpdated & clearOnSelect 1`] = `
+exports[`Autocomplete component should render with props: onDropdownChange & clearOnSelect 1`] = `
 <DocumentFragment>
   <div
     class="autocomplete-container"

--- a/src/components/__tests__/autocomplete.spec.tsx
+++ b/src/components/__tests__/autocomplete.spec.tsx
@@ -36,6 +36,19 @@ describe('Autocomplete component', () => {
     fireEvent.change(searchInput, { target: { value } });
     fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter' });
     expect(onSelect).toHaveBeenCalledWith(value);
+    expect(searchInput).toHaveValue(value);
+  });
+
+  it('should clear on Enter if clearOnSelect is passed', () => {
+    const onSelect = jest.fn();
+    render(
+      <Autocomplete data={flattenedPaths} onSelect={onSelect} clearOnSelect />
+    );
+    const searchInput = screen.getByTestId('search-input');
+    const value = 'foo';
+    fireEvent.change(searchInput, { target: { value } });
+    fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter' });
+    expect(searchInput).toHaveValue('');
   });
 });
 
@@ -77,5 +90,17 @@ describe('filterOptions', () => {
 describe('shouldShowDropdown', () => {
   it('should return false if length of text input is less than minCharsToShowDropdown', () => {
     expect(shouldShowDropdown('fo', [], true, true, 3)).toBe(false);
+  });
+
+  it('should return true if text input is in options', () => {
+    expect(shouldShowDropdown('Item', flattenedPaths, false, true, 3)).toBe(
+      true
+    );
+  });
+
+  it('should return true if filtering is not applied', () => {
+    expect(shouldShowDropdown('Zzz', flattenedPaths, false, false, 3)).toBe(
+      true
+    );
   });
 });

--- a/src/components/__tests__/autocomplete.spec.tsx
+++ b/src/components/__tests__/autocomplete.spec.tsx
@@ -16,28 +16,26 @@ describe('Autocomplete component', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render with props: showDropdownUpdated & clearOnSelect', () => {
+  it('should render with props: onDropdownChange & clearOnSelect', () => {
     const { asFragment } = render(
       <Autocomplete
         data={flattenedPaths}
         onSelect={jest.fn()}
-        showDropdownUpdated={(d) => d}
+        onDropdownChange={(d) => d}
         clearOnSelect
       />
     );
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should not submit if previously submitted text is the same as the current input text value', () => {
+  it('should submit current input text value', () => {
     const onSelect = jest.fn();
     render(<Autocomplete data={flattenedPaths} onSelect={onSelect} />);
     const searchInput = screen.getByTestId('search-input');
-    const value = { target: { value: 'foo' } };
-    fireEvent.change(searchInput, value);
+    const value = 'foo';
+    fireEvent.change(searchInput, { target: { value } });
     fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter' });
-    fireEvent.change(searchInput, value);
-    fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter' });
-    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(value);
   });
 });
 

--- a/src/components/autocomplete.tsx
+++ b/src/components/autocomplete.tsx
@@ -93,17 +93,16 @@ const Autocomplete = ({
   const handleInputChange = useCallback(
     (event) => {
       const { value: textInputValue } = event.target;
-      const selected = false;
       const showDropdown = shouldShowDropdown(
         textInputValue,
         data,
-        selected,
+        false,
         filter,
         minCharsToShowDropdown
       );
       onDropdownChange?.(showDropdown);
       setTextInputValue(textInputValue);
-      setSelected(selected);
+      setSelected(false);
       onChange?.(textInputValue);
       if (showDropdown) {
         setHoverIndex(0);

--- a/src/components/tree-select.tsx
+++ b/src/components/tree-select.tsx
@@ -153,7 +153,7 @@ const TreeSelect = <Item extends BasicItem<Item>>({
               data={restructureFlattenedTreeDataForAutocomplete(
                 getFlattenedPaths(data)
               )}
-              showDropdownUpdated={setAutocompleteShowDropdown}
+              onDropdownChange={setAutocompleteShowDropdown}
               onSelect={(node: AutocompleteItemType | string) =>
                 handleNodeClick(node, setShowDropdownMenu)
               }


### PR DESCRIPTION
## Purpose
Autocomplete: selecting a node that was previously selected will not close dropdown [[jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-22978)]

## Approach
* Allow previously selected value to be resubmitted

Additionally:
* On unmount tell the parent that the dropdown menu isn't being shown anymore as it was possible for the `TreeSelect` with `autocomplete` to show only text input box. Eg going to the existing [component story](https://ebi-uniprot.github.io/franklin-sites/?path=/story/forms-tree-select--tree-select-with-autocomplete) and inputting "a", clicking outside to close, then reopening will show:
<img width="111" alt="Screenshot 2021-08-19 at 12 47 22" src="https://user-images.githubusercontent.com/4357962/130063395-ed9b128f-974c-4643-9655-bd698271485a.png">

* Immediately select first suggested item when typing so that user needs only press enter - not sure if this breaks any aria rules? Noticed myself that I would have to keep tapping down when I typically want the first suggestion.
* Changed `showDropdownUpdated` to (what I think) is slightly clearer `onDropdownChange`

## Testing
Updated

## Stories
Not touched

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
