### PR TITLE
Info list item link

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,6 @@ deploy:
     - cp -r .out/* franklin-sites
     - cd franklin-sites
     - git add -A
-    - test -z "$(git status --porcelain)" && exit 0 # Don't push if no changes
+    - test -z "$(git status --porcelain)" && exit 0 # Don't commit and push if no changes
     - git commit -m "Deploy gitlab.ebi.ac.uk/uniprot/uniprot-website/franklin-sites to github.com/ebi-uniprot/franklin-sites.git:gh-pages"
     - git push origin gh-pages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,6 @@ deploy:
     - cp -r .out/* franklin-sites
     - cd franklin-sites
     - git add -A
-    - test -z "$(git status --porcelain)" && exit 0
+    - test -z "$(git status --porcelain)" && exit 0 # Don't push if no changes
     - git commit -m "Deploy gitlab.ebi.ac.uk/uniprot/uniprot-website/franklin-sites to github.com/ebi-uniprot/franklin-sites.git:gh-pages"
     - git push origin gh-pages

--- a/src/components/__tests__/__snapshots__/decorated-list-item.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/decorated-list-item.spec.tsx.snap
@@ -74,6 +74,27 @@ exports[`DecoratedListItem component should render inline 1`] = `
 </DocumentFragment>
 `;
 
+exports[`DecoratedListItem component should render link and navigate when clicked 1`] = `
+<DocumentFragment>
+  <div
+    class="decorated-list-item decorated-list-item--has-link"
+  >
+    <a
+      aria-hidden="true"
+      class="decorated-list-item__link"
+      data-testid="background-link"
+      href="/target"
+      tabindex="-1"
+    />
+    <div
+      class="decorated-list-item__content"
+    >
+      Content
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`DecoratedListItem component should render without title 1`] = `
 <DocumentFragment>
   <div

--- a/src/components/__tests__/decorated-list-item.spec.tsx
+++ b/src/components/__tests__/decorated-list-item.spec.tsx
@@ -1,4 +1,6 @@
-import { render } from '@testing-library/react';
+import { screen, fireEvent, render } from '@testing-library/react';
+
+import renderWithRouter from '../../testHelpers/renderWithRouter';
 
 import DecoratedListItem from '../decorated-list-item';
 
@@ -38,5 +40,14 @@ describe('DecoratedListItem component', () => {
       <DecoratedListItem inline>Content</DecoratedListItem>
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('should render link and navigate when clicked', () => {
+    const { asFragment, history } = renderWithRouter(
+      <DecoratedListItem to="/target">Content</DecoratedListItem>
+    );
+    expect(asFragment()).toMatchSnapshot();
+    fireEvent.click(screen.getByTestId('background-link'));
+    expect(history.location.pathname).toBe('/target');
   });
 });

--- a/src/components/decorated-list-item.tsx
+++ b/src/components/decorated-list-item.tsx
@@ -14,7 +14,7 @@ type Props = {
    */
   highlight?: boolean;
   /**
-   * Target/link of the card when clicking on it
+   * Target/link of the list item when clicking on it
    */
   to?: LinkProps['to'];
   /**

--- a/src/components/decorated-list-item.tsx
+++ b/src/components/decorated-list-item.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from 'react';
 import cn from 'classnames';
+import { Link, LinkProps } from 'react-router-dom';
 
 import '../styles/components/decorated-list-item.scss';
 
@@ -12,6 +13,10 @@ type Props = {
    * Make this item visually stand-out
    */
   highlight?: boolean;
+  /**
+   * Target/link of the card when clicking on it
+   */
+  to?: LinkProps['to'];
   /**
    * Compact style
    */
@@ -37,6 +42,7 @@ type Props = {
 const DecoratedListItem: FC<Props> = ({
   title,
   children,
+  to,
   highlight,
   compact,
   hideTitle,
@@ -51,9 +57,19 @@ const DecoratedListItem: FC<Props> = ({
       'decorated-list-item--no-title': hideTitle,
       'decorated-list-item--inline': inline,
       'decorated-list-item--alt-style': altStyle,
+      'decorated-list-item--has-link': to,
     })}
     {...props}
   >
+    {to && (
+      <Link
+        data-testid="background-link"
+        to={to}
+        className="decorated-list-item__link"
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+    )}
     {title && (
       <div className="decorated-list-item__title">
         <h5 className="bold">{title}</h5>

--- a/src/components/info-list.tsx
+++ b/src/components/info-list.tsx
@@ -5,7 +5,12 @@ import DecoratedListItem from './decorated-list-item';
 
 import '../styles/components/info-list.scss';
 
-type Item = { title: ReactNode; content: ReactNode; key?: string };
+type Item = {
+  title: ReactNode;
+  content: ReactNode;
+  key?: string;
+  to?: string;
+};
 
 type Props = {
   /**
@@ -53,7 +58,7 @@ const InfoList: FC<Props> = ({
   >
     {infoData.map(
       // Only draw if there is content
-      ({ content, title, key }, index) =>
+      ({ content, title, key, to }, index) =>
         content && (
           <li key={key || (typeof title === 'string' ? title : index)}>
             <DecoratedListItem
@@ -61,6 +66,7 @@ const InfoList: FC<Props> = ({
               highlight={index === 0 && highlightFirstItem}
               compact={isCompact}
               hideTitle={noTitles}
+              to={to}
             >
               {content}
             </DecoratedListItem>

--- a/src/styles/components/decorated-list-item.scss
+++ b/src/styles/components/decorated-list-item.scss
@@ -98,9 +98,10 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
     cursor: pointer;
   }
 
+  // Lifted from card style
   &--has-link {
     transition: 0.5s background-color ease;
-    position: relative;
+    position: relative; // Needed this otherwise the whole list becomes the anchor element
 
     &:hover,
     &:focus-within {

--- a/src/styles/components/decorated-list-item.scss
+++ b/src/styles/components/decorated-list-item.scss
@@ -15,9 +15,7 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
   &__title {
     flex-basis: 10vw;
     flex-shrink: 0;
-    margin-right: 0.7rem;
     text-align: right;
-    border-right: $decorative-bar;
     padding-right: 0.7rem;
     h5 {
       line-height: 1.2;
@@ -25,6 +23,10 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
   }
 
   &__content {
+    padding-left: 0.7rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    border-left: $decorative-bar;
     ul {
       margin-bottom: 0;
     }
@@ -124,10 +126,10 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
 
     &__title {
       text-align: left;
-      border-right: 0;
     }
     &__content {
       border-left: none;
+      padding-left: 0;
       padding-left: 0;
     }
   }

--- a/src/styles/components/decorated-list-item.scss
+++ b/src/styles/components/decorated-list-item.scss
@@ -10,6 +10,7 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
   display: flex;
   align-items: baseline;
   margin-bottom: 1.25rem;
+  padding: 0;
 
   &__title {
     flex-basis: 10vw;
@@ -85,6 +86,36 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
       }
     }
   }
+
+  &__link {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    cursor: pointer;
+  }
+
+  &--has-link {
+    transition: 0.5s background-color ease;
+    position: relative;
+
+    &:hover,
+    &:focus-within {
+      background-color: scale-color($color: $colour-platinum, $lightness: 40%);
+    }
+
+    * {
+      pointer-events: none;
+    }
+
+    a,
+    button,
+    input,
+    label {
+      pointer-events: initial;
+    }
+  }
 }
 
 @include breakpoint(small only) {
@@ -93,6 +124,7 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
 
     &__title {
       text-align: left;
+      border-right: 0;
     }
     &__content {
       border-left: none;

--- a/src/styles/components/decorated-list-item.scss
+++ b/src/styles/components/decorated-list-item.scss
@@ -131,7 +131,6 @@ $alt-decorative-bar: 0.25rem solid $colour-pastel-blue;
     &__content {
       border-left: none;
       padding-left: 0;
-      padding-left: 0;
     }
   }
 }

--- a/stories/InfoList.stories.tsx
+++ b/stories/InfoList.stories.tsx
@@ -35,6 +35,11 @@ const data = [
     ),
     content: loremIpsum({ count: 25, units: 'words' }),
   },
+  {
+    title: 'This item is a link',
+    content: loremIpsum({ count: 25, units: 'words' }),
+    to: '#',
+  },
 ];
 
 export const infoList = () => <InfoList infoData={data} />;


### PR DESCRIPTION
## Purpose
* Allow info list item to be a link.
* Don't show border when view is small and items become rows.
* Use content for border as presumably this will be taller.

**BEFORE**
<img width="470" alt="Screenshot 2021-09-03 at 13 21 29" src="https://user-images.githubusercontent.com/4357962/132005408-0787cd87-8274-4ee7-9496-19071d43d65d.png">


**AFTER**
<img width="407" alt="Screenshot 2021-09-03 at 13 21 35" src="https://user-images.githubusercontent.com/4357962/132005404-a5b475e7-88e1-424d-9883-1eee3bb53e40.png">

## Approach
Copy/pasted approach used in Card

## Testing
Added unit test

## Stories
Added info list item with a link.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
