### PR TITLE
Remove unecessary story, add knob

### DIFF
--- a/stories/Tile.stories.tsx
+++ b/stories/Tile.stories.tsx
@@ -21,42 +21,37 @@ export default {
 };
 
 export const BasicTile = () => (
-  <Tile
-    title={text('title', 'Title', 'Props')}
-    headingLevel={select(
-      'headingLevel',
-      ['h1', 'h2', 'h3', 'h4', 'h5'],
-      'h3',
-      'Props'
-    )}
-    backgroundColor={select(
-      '--tile-background',
-      colors,
-      colors.seaBlue,
-      'Custom Properties'
-    )}
-    backgroundImage={boolean('with background?', false) ? <SVG /> : null}
-    subtitle={text('subtitle', 'subtitle', 'Props')}
-    width="20rem"
-    gradient={boolean('gradient', false, 'Props')}
-    to="/"
-    descriptionSlideUp={boolean('Slide up description', false, 'Props')}
-  >
-    {loremIpsum()}
-    {boolean('button in description', false) ? (
-      <button
-        type="button"
-        onClick={action('description button clicked')}
-        style={{ color: 'currentcolor', background: 'black' }}
-      >
-        Some button
-      </button>
-    ) : null}
-  </Tile>
-);
-
-export const TileWithContainer = () => (
-  <div style={{ width: '40%' }}>
-    <BasicTile />
+  <div style={{ width: text('Container size', '40%', 'ContainerProps') }}>
+    <Tile
+      title={text('title', 'Title', 'Props')}
+      headingLevel={select(
+        'headingLevel',
+        ['h1', 'h2', 'h3', 'h4', 'h5'],
+        'h3',
+        'Props'
+      )}
+      backgroundColor={select(
+        '--tile-background',
+        colors,
+        colors.seaBlue,
+        'Custom Properties'
+      )}
+      backgroundImage={boolean('with background?', false) ? <SVG /> : null}
+      subtitle={text('subtitle', 'subtitle', 'Props')}
+      gradient={boolean('gradient', false, 'Props')}
+      to="/"
+      descriptionSlideUp={boolean('Slide up description', false, 'Props')}
+    >
+      {loremIpsum()}
+      {boolean('button in description', false) ? (
+        <button
+          type="button"
+          onClick={action('description button clicked')}
+          style={{ color: 'currentcolor', background: 'black' }}
+        >
+          Some button
+        </button>
+      ) : null}
+    </Tile>
   </div>
 );


### PR DESCRIPTION


## Purpose
Noticed the "with container" story wasn't working as the size was defined in BasicTile

## Approach
Add the container around the BasicTile, and add a knob to set its value.

## Testing
What test(s) did you write to validate and verify your changes?

N/A

## Stories
What story(ies) did you write or change to document the functionality / changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
