### PR TITLE
sliding panel, reason for closing, and closing through escape key

### DIFF
--- a/src/components/__tests__/sliding-panel.spec.tsx
+++ b/src/components/__tests__/sliding-panel.spec.tsx
@@ -10,7 +10,7 @@ describe('SlidingPanel component', () => {
     const onClose = jest.fn();
     renderWithRouter(
       <>
-        <div data-testid="outside-component" />
+        <div data-testid="outside-element" />
         <SlidingPanel onClose={onClose} position="left" title="Title">
           Sliding panel content
         </SlidingPanel>
@@ -18,8 +18,47 @@ describe('SlidingPanel component', () => {
     );
     fireEvent.click(screen.getByText('Sliding panel content'));
     await sleep(200);
-    fireEvent.click(screen.getByTestId('outside-component'));
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    fireEvent.click(screen.getByTestId('outside-element'));
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith('outside'));
+  });
+
+  it('should call onClose when closing through the close button', async () => {
+    const onClose = jest.fn();
+    renderWithRouter(
+      <SlidingPanel
+        onClose={onClose}
+        position="left"
+        title="Title"
+        withCloseButton
+      >
+        Sliding panel content
+      </SlidingPanel>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith('button'));
+  });
+
+  it('should call onClose when pressing escape (within and outside the panel)', async () => {
+    const onClose = jest.fn();
+    renderWithRouter(
+      <>
+        <input data-testid="outside-element" />
+        <SlidingPanel onClose={onClose} position="left" title="Title">
+          <input data-testid="inside-element" />
+        </SlidingPanel>
+      </>
+    );
+    fireEvent.keyDown(screen.getByTestId('inside-element'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith('escape'));
+    onClose.mockClear();
+    fireEvent.keyDown(screen.getByTestId('outside-element'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith('escape'));
   });
 
   it('should move focus around correctly', async () => {

--- a/src/components/sliding-panel.tsx
+++ b/src/components/sliding-panel.tsx
@@ -1,12 +1,4 @@
-import {
-  FC,
-  useRef,
-  useEffect,
-  ReactNode,
-  HTMLAttributes,
-  useCallback,
-  KeyboardEventHandler,
-} from 'react';
+import { FC, useRef, useEffect, ReactNode, HTMLAttributes } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation } from 'react-router-dom';
 import cn from 'classnames';
@@ -155,15 +147,21 @@ const SlidingPanel: FC<
     // keep pathname below, this is to trigger the effect when it changes
   }, [pathname]);
 
-  const handleKeyDown: KeyboardEventHandler = useCallback((event) => {
-    if (event.key === 'Escape') {
-      onCloseRef.current?.('escape');
-    }
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onCloseRef.current?.('escape');
+      }
+    };
+
+    document.addEventListener('keydown', listener, { passive: true });
+
+    return () => {
+      document.removeEventListener('keydown', listener);
+    };
   }, []);
 
   return createPortal(
-    // event bubbling, so that's why we override this rule
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <aside
       data-testid="sliding-panel"
       className={cn(
@@ -174,9 +172,6 @@ const SlidingPanel: FC<
         className
       )}
       ref={node}
-      onKeyDown={handleKeyDown}
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex={0}
       {...props}
     >
       {(title || withCloseButton) && (
@@ -189,6 +184,7 @@ const SlidingPanel: FC<
               variant="tertiary"
               onClick={() => onCloseRef.current?.('button')}
               className="sliding-panel__header__buttons"
+              title="Close panel"
             >
               <CloseIcon />
             </Button>

--- a/stories/SlidingPanel.stories.tsx
+++ b/stories/SlidingPanel.stories.tsx
@@ -38,7 +38,7 @@ export const SlidingPanels = () => {
       position={position}
       size={size}
       withCloseButton={withCloseButton}
-      onClose={() => action('Closing')}
+      onClose={action('Closing')}
     >
       {loremIpsum({ count: 25 })}
     </SlidingPanel>
@@ -65,19 +65,12 @@ export const SlidingPanelsWithArrow = () => {
     [position]
   );
 
-  const onButtonClick = () => {
-    setShowPanel(true);
-  };
-
-  const onClose = () => {
-    setShowPanel(false);
-    action('onClose');
-  };
-
   return (
     <>
       <Button
-        onClick={onButtonClick}
+        onClick={() => {
+          setShowPanel(true);
+        }}
         style={{
           position: 'absolute',
           top: '-2rem',
@@ -94,7 +87,10 @@ export const SlidingPanelsWithArrow = () => {
           position={position}
           size={size}
           withCloseButton={withCloseButton}
-          onClose={onClose}
+          onClose={(reason) => {
+            setShowPanel(false);
+            action('onClose')(reason);
+          }}
           arrowX={arrowX}
         >
           {loremIpsum({ count: 25 })}
@@ -132,10 +128,10 @@ export const SlidingPanelInSlidingPanel = () => {
           position={position}
           size={size}
           withCloseButton={withCloseButton}
-          onClose={() => {
+          onClose={(reason) => {
             setShowPanel(false);
             setShowPanel2(false);
-            action('onClose 1');
+            action('onClose 1')(reason);
           }}
         >
           <>
@@ -148,9 +144,9 @@ export const SlidingPanelInSlidingPanel = () => {
                 position={position}
                 size={size}
                 withCloseButton={withCloseButton}
-                onClose={() => {
+                onClose={(reason) => {
                   setShowPanel2(false);
-                  action('onClose 2');
+                  action('onClose 2')(reason);
                 }}
               >
                 {loremIpsum({ count: 25 })}


### PR DESCRIPTION
## Purpose & approach
To cater for the needs of the contextual help, pass the reason for which the `onClose` callback has been called
Also, add support for closing through the escape key (see end of PR description)

## Testing
Added new tests

## Stories
sliding-panel

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?

~Pending question:~
~To enable the "press Escape key" behaviour, I need to listen to the key down event. It is only emitted from within focusable elements. There are multiple ways to handle this:~
 - ~Make the sliding panel focusable (but it will appear in the tabbing flow), event listener on the sliding panel. Any key press inside will be picked up -> current approach in this draft~
 - ~Event listener on the sliding panel, relying on the focus being moved to the first focusable element within automatically, event bubbling will make it so that the sliding panel gets the key press (but what if there are no focusable element within? Not the case afaik)~
 - Event listener on the whole document, any escape key pressed when focus inside or outside the sliding panel will make it close

~And maybe another approach could be possible.~
