### PR TITLE
Add tippy, tooltips to column headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-router-dom": "5.x"
   },
   "dependencies": {
+    "@tippyjs/react": "^4.2.6",
     "classnames": "2.3.1",
     "d3": "5.16.0",
     "foundation-sites": "6.7.4",
@@ -100,6 +101,7 @@
     "rehype-raw": "6.1.1",
     "rheostat": "4.1.1",
     "timing-functions": "2.0.1",
+    "tippy.js": "^6.3.7",
     "type-fest": "2.8.0",
     "uuid": "8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "rehype-raw": "6.1.1",
     "rheostat": "4.1.1",
     "timing-functions": "2.0.1",
-    "tippy.js": "^6.3.7",
+    "tippy.js": "6.3.7",
     "type-fest": "2.8.0",
     "uuid": "8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-router-dom": "5.x"
   },
   "dependencies": {
-    "@tippyjs/react": "^4.2.6",
+    "@tippyjs/react": "4.2.6",
     "classnames": "2.3.1",
     "d3": "5.16.0",
     "foundation-sites": "6.7.4",

--- a/src/components/__tests__/__snapshots__/data-table.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/data-table.spec.tsx.snap
@@ -26,19 +26,25 @@ exports[`DataTable should render autoload 1`] = `
         <th
           class="data-table__header-cell--sortable data-table__header-cell--ascend"
         >
-          Column 1
+          <span>
+            Column 1
+          </span>
         </th>
         <th
           class=""
         >
-          Column 2
+          <span>
+            Column 2
+          </span>
         </th>
         <th
           class="data-table__header-cell--sortable"
         >
-          <h1>
-            Column 3
-          </h1>
+          <span>
+            <h1>
+              Column 3
+            </h1>
+          </span>
         </th>
       </tr>
     </thead>
@@ -337,19 +343,25 @@ exports[`DataTable should render click-to-load 1`] = `
         <th
           class="data-table__header-cell--sortable data-table__header-cell--ascend"
         >
-          Column 1
+          <span>
+            Column 1
+          </span>
         </th>
         <th
           class=""
         >
-          Column 2
+          <span>
+            Column 2
+          </span>
         </th>
         <th
           class="data-table__header-cell--sortable"
         >
-          <h1>
-            Column 3
-          </h1>
+          <span>
+            <h1>
+              Column 3
+            </h1>
+          </span>
         </th>
       </tr>
     </thead>

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -97,7 +97,7 @@ const DataTableHead = <Datum extends BasicDatum>({
           style={width ? { width } : undefined}
         >
           {typeof tooltip !== 'undefined' ? (
-            <Tippy content={tooltip}>
+            <Tippy content={tooltip} interactive>
               <TableHeaderContent label={label} />
             </Tippy>
           ) : (

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -5,9 +5,11 @@ import {
   HTMLAttributes,
   useRef,
   useMemo,
+  forwardRef,
 } from 'react';
 import cn from 'classnames';
 import { v1 } from 'uuid';
+import Tippy from '@tippyjs/react';
 
 import Loader from './loader';
 
@@ -17,12 +19,15 @@ import withDataLoader, { WrapperProps } from './data-loader';
 
 import '../styles/components/data-table.scss';
 
+import 'tippy.js/dist/tippy.css';
+
 type BasicDatum = Record<string, unknown>;
 
 type CommonColumn<Datum> = {
   label?: ReactNode;
   name: string;
   render: (datum: Datum) => ReactNode;
+  tooltip?: ReactNode;
   width?: string;
 };
 
@@ -61,6 +66,12 @@ type HeadProps<Datum> = {
   onHeaderClick?: (columnName: SortableColumn<Datum>['name']) => void;
 };
 
+const TableHeaderContent = forwardRef<HTMLElement, { label: ReactNode }>(
+  ({ label }, ref) => (
+    <span ref={ref}>{typeof label === 'function' ? label() : label}</span>
+  )
+);
+
 const DataTableHead = <Datum extends BasicDatum>({
   columns,
   onHeaderClick,
@@ -74,7 +85,7 @@ const DataTableHead = <Datum extends BasicDatum>({
           <div className="checkbox-cell">{checkbox}</div>
         </th>
       )}
-      {columns.map(({ sorted, name, label, sortable, width }) => (
+      {columns.map(({ sorted, name, label, tooltip, sortable, width }) => (
         <th
           key={name}
           className={cn({
@@ -85,7 +96,13 @@ const DataTableHead = <Datum extends BasicDatum>({
           onClick={sortable ? () => onHeaderClick?.(name) : undefined}
           style={width ? { width } : undefined}
         >
-          {typeof label === 'function' ? label() : label}
+          {typeof tooltip !== 'undefined' ? (
+            <Tippy content={tooltip}>
+              <TableHeaderContent label={label} />
+            </Tippy>
+          ) : (
+            <TableHeaderContent label={label} />
+          )}
         </th>
       ))}
     </tr>

--- a/src/components/info-list.tsx
+++ b/src/components/info-list.tsx
@@ -5,7 +5,7 @@ import DecoratedListItem from './decorated-list-item';
 
 import '../styles/components/info-list.scss';
 
-type Item = {
+export type InfoListItem = {
   title: ReactNode;
   content: ReactNode;
   key?: string;
@@ -16,7 +16,7 @@ type Props = {
   /**
    * An array of objects each containing 'title' and 'content'
    */
-  infoData?: Array<Item>;
+  infoData?: Array<InfoListItem>;
   /**
    * A boolean indicating whether the component should span multiple
    * columns on medium to large screens or not.

--- a/src/components/sequence.tsx
+++ b/src/components/sequence.tsx
@@ -20,6 +20,8 @@ import {
   Button,
 } from '.';
 
+import { InfoListItem } from './info-list';
+
 import aminoAcidsProps from './data/amino-acid-properties.json';
 
 import '../styles/components/sequence.scss';
@@ -128,10 +130,7 @@ type SequenceProps = {
   /**
    * Data to be displayed in an InfoData component above the sequence
    */
-  infoData?: {
-    title: ReactNode;
-    content: ReactNode;
-  }[];
+  infoData?: InfoListItem[];
   /**
    * The URL to download the isoform sequence
    */

--- a/src/components/sequence.tsx
+++ b/src/components/sequence.tsx
@@ -129,7 +129,7 @@ type SequenceProps = {
    * Data to be displayed in an InfoData component above the sequence
    */
   infoData?: {
-    title: string;
+    title: ReactNode;
     content: ReactNode;
   }[];
   /**

--- a/src/decorators/DataDecorator.tsx
+++ b/src/decorators/DataDecorator.tsx
@@ -31,7 +31,8 @@ export const columns: Array<
     name: 'content2',
     tooltip: (
       <>
-        Some <strong>richer</strong> content for the tooltip
+        Some <strong>richer</strong> content for the tooltip with a{' '}
+        <ExternalLink url="https://www.uniprot.org">link</ExternalLink>
       </>
     ),
     render: (row) => row.content2,

--- a/src/decorators/DataDecorator.tsx
+++ b/src/decorators/DataDecorator.tsx
@@ -9,6 +9,7 @@ import {
   NonSortableColumn,
 } from '../components/data-table';
 import { WrapperProps } from '../components/data-loader';
+import { ExternalLink } from '../components';
 
 type DataType = Record<string, string>;
 type CommonProps = DataListProps<DataType> | DataTableProps<DataType>;

--- a/src/decorators/DataDecorator.tsx
+++ b/src/decorators/DataDecorator.tsx
@@ -21,6 +21,7 @@ export const columns: Array<
   {
     label: 'Column 1',
     name: 'content1',
+    tooltip: 'Some content for the tooltip',
     render: (row) => row.content1,
     sortable: true,
     sorted: 'descend',
@@ -28,6 +29,11 @@ export const columns: Array<
   {
     label: 'Column 2',
     name: 'content2',
+    tooltip: (
+      <>
+        Some <strong>richer</strong> content for the tooltip
+      </>
+    ),
     render: (row) => row.content2,
   },
   {

--- a/src/decorators/DataDecorator.tsx
+++ b/src/decorators/DataDecorator.tsx
@@ -41,6 +41,12 @@ export const columns: Array<
   {
     label: 'Column 3',
     name: 'content3',
+    tooltip: (
+      <>
+        Some <strong>richer</strong> content for the tooltip with a{' '}
+        <a href="https://www.uniprot.org">link</a>
+      </>
+    ),
     render: (row) => row.content3,
     sortable: true,
   },

--- a/src/styles/components/data-table.scss
+++ b/src/styles/components/data-table.scss
@@ -173,4 +173,10 @@
       white-space: nowrap;
     }
   }
+
+  // Tippy link styling
+  .tippy-content a.external-link {
+    color: white;
+    text-decoration: underline;
+  }
 }

--- a/src/styles/components/data-table.scss
+++ b/src/styles/components/data-table.scss
@@ -175,6 +175,7 @@
   }
 
   // Tippy link styling
+  .tippy-content a,
   .tippy-content a.external-link {
     color: white;
     text-decoration: underline;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,6 +2496,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
+"@popperjs/core@^2.9.0":
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
+  integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
+
 "@reach/router@^1.2.1", "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -3494,6 +3499,13 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
+
+"@tippyjs/react@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.6.tgz#971677a599bf663f20bb1c60a62b9555b749cc71"
+  integrity sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==
+  dependencies:
+    tippy.js "^6.3.1"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -14949,6 +14961,13 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tippy.js@^6.3.1, tippy.js@^6.3.7:
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
+  integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==
+  dependencies:
+    "@popperjs/core" "^2.9.0"
 
 tmpl@1.0.x:
   version "1.0.5"


### PR DESCRIPTION
## Purpose
Add tooltips functionality to column headers.

## Approach
Added dependency on Tippy (and react Tippy). Had to add a `forwardRef` to make it work with the column headers.

## Testing
Update snapshots.

## Stories
Updated default content to add 2 examples (first 2 columns)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
