### PR TITLE
Tree select with tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ merge_and_test:
     - git config --global user.name "UniProt CI"
     - git fetch origin $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME
     - git checkout $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME
+    - git reset --hard origin/$CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME
     - git merge $CI_COMMIT_SHA --no-ff -m "Merge and test"
     - test -n "$(git status --porcelain)" && exit 1 # Exit if merge has conflicts
     - yarn

--- a/src/__tests__/utils.spec.tsx
+++ b/src/__tests__/utils.spec.tsx
@@ -4,8 +4,7 @@ import { render } from '@testing-library/react';
 import {
   getNodePaths,
   getLastIndexOfSubstringIgnoreCase,
-  restructureFlattenedTreeDataForAutocomplete,
-  restructureFlattenedTreeItemsForAutocomplete,
+  prepareTreeDataForAutocomplete,
   getSingleChildren,
   highlightSubstring,
   tidyUrlString,
@@ -34,6 +33,7 @@ it('should get all paths', () => {
       {
         label: 'Item 1b',
         id: 'item_1b',
+        tags: ['tag2', 'tag3'],
       },
       {
         label: 'Item 1b A',
@@ -48,6 +48,7 @@ it('should get all paths', () => {
       {
         label: 'Item 1b',
         id: 'item_1b',
+        tags: ['tag2', 'tag3'],
       },
       {
         label: 'Item 1b B',
@@ -102,6 +103,7 @@ it('should find the correct path', () => {
       {
         label: 'Item 1b',
         id: 'item_1b',
+        tags: ['tag2', 'tag3'],
       },
       {
         label: 'Item 1b B',
@@ -128,7 +130,7 @@ it('should not find the index of the last string', () => {
 
 it('should prepare all tree data for autocomplete', () => {
   const flatPaths = getNodePaths(treeData);
-  const data = restructureFlattenedTreeDataForAutocomplete(flatPaths);
+  const data = prepareTreeDataForAutocomplete(flatPaths);
   expect(data).toEqual([
     {
       id: 'item_1a',
@@ -139,11 +141,13 @@ it('should prepare all tree data for autocomplete', () => {
       id: 'item_1b_A',
       pathLabel: 'Item 1 / Item 1b / Item 1b A',
       itemLabel: 'Item 1b A',
+      tags: ['tag2', 'tag3'],
     },
     {
       id: 'item_1b_B',
       pathLabel: 'Item 1 / Item 1b / Item 1b B',
       itemLabel: 'Item 1b B',
+      tags: ['tag2', 'tag3'],
     },
     {
       id: 'item_2',
@@ -163,25 +167,6 @@ it('should prepare all tree data for autocomplete', () => {
         'Another reaaaaalllllyyyyy looooooong Item 3 / Item 3a (single child, open by default) / Item 3a B',
     },
   ]);
-});
-
-it('should prepare flattened tree data items for autocomplete', () => {
-  const items = [
-    {
-      label: 'Item 1',
-      id: 'item_1',
-    },
-    {
-      label: 'Item 1a',
-      id: 'item_1a',
-    },
-  ];
-  const data = restructureFlattenedTreeItemsForAutocomplete(items);
-  expect(data).toEqual({
-    id: 'item_1a',
-    pathLabel: 'Item 1 / Item 1a',
-    itemLabel: 'Item 1a',
-  });
 });
 
 it('should yield single children from a tree of items', () => {

--- a/src/__tests__/utils.spec.tsx
+++ b/src/__tests__/utils.spec.tsx
@@ -2,7 +2,7 @@
 import { render } from '@testing-library/react';
 
 import {
-  getFlattenedPaths,
+  getNodePaths,
   getLastIndexOfSubstringIgnoreCase,
   restructureFlattenedTreeDataForAutocomplete,
   restructureFlattenedTreeItemsForAutocomplete,
@@ -14,8 +14,8 @@ import {
 import { treeData } from '../mock-data/tree-data';
 
 it('should get all paths', () => {
-  const path = getFlattenedPaths(treeData);
-  expect(path).toEqual([
+  const paths = getNodePaths(treeData);
+  expect(paths).toEqual([
     [
       {
         label: 'Item 1',
@@ -92,7 +92,7 @@ it('should get all paths', () => {
 });
 
 it('should find the correct path', () => {
-  const path = getFlattenedPaths(treeData, 'item_1b_B');
+  const path = getNodePaths(treeData, 'item_1b_B');
   expect(path).toEqual([
     [
       {
@@ -112,7 +112,7 @@ it('should find the correct path', () => {
 });
 
 it('should not find any paths', () => {
-  const path = getFlattenedPaths(treeData, 'The unfindable');
+  const path = getNodePaths(treeData, 'The unfindable');
   expect(path).toEqual([]);
 });
 
@@ -127,7 +127,7 @@ it('should not find the index of the last string', () => {
 });
 
 it('should prepare all tree data for autocomplete', () => {
-  const flatPaths = getFlattenedPaths(treeData);
+  const flatPaths = getNodePaths(treeData);
   const data = restructureFlattenedTreeDataForAutocomplete(flatPaths);
   expect(data).toEqual([
     {

--- a/src/components/__tests__/autocomplete.spec.tsx
+++ b/src/components/__tests__/autocomplete.spec.tsx
@@ -85,6 +85,28 @@ describe('filterOptions', () => {
     ];
     expect(filtered).toEqual(expected);
   });
+  it('should filter options when a tag is provided', () => {
+    const options = [
+      {
+        pathLabel: 'Do not find this',
+      },
+      {
+        pathLabel: 'Also do not find this',
+      },
+      {
+        pathLabel: 'Find this because it is tagged',
+        tags: ['tagged'],
+      },
+    ];
+    const filtered = filterOptions(options as AutocompleteItemType[], 'tagged');
+    const expected = [
+      {
+        pathLabel: 'Find this because it is tagged',
+        tags: ['tagged'],
+      },
+    ];
+    expect(filtered).toEqual(expected);
+  });
 });
 
 describe('shouldShowDropdown', () => {

--- a/src/components/__tests__/autocomplete.spec.tsx
+++ b/src/components/__tests__/autocomplete.spec.tsx
@@ -94,14 +94,14 @@ describe('filterOptions', () => {
         pathLabel: 'Also do not find this',
       },
       {
-        pathLabel: 'Find this because it is tagged',
+        pathLabel: 'Find this because it is marked in a hidden tag',
         tags: ['tagged'],
       },
     ];
     const filtered = filterOptions(options as AutocompleteItemType[], 'tagged');
     const expected = [
       {
-        pathLabel: 'Find this because it is tagged',
+        pathLabel: 'Find this because it is marked in a hidden tag',
         tags: ['tagged'],
       },
     ];

--- a/src/components/autocomplete-item.tsx
+++ b/src/components/autocomplete-item.tsx
@@ -6,6 +6,7 @@ export type AutocompleteItemType = {
   pathLabel: string;
   itemLabel: string;
   items?: AutocompleteItemType[];
+  tags?: string[];
 };
 
 type AutocompleteItemProps = {

--- a/src/components/autocomplete.tsx
+++ b/src/components/autocomplete.tsx
@@ -20,7 +20,9 @@ export const filterOptions = (items: AutocompleteItemType[], query: string) =>
   items.filter(
     (item) =>
       getLastIndexOfSubstringIgnoreCase(item.pathLabel, query) >= 0 ||
-      item.tags?.some((tag) => getLastIndexOfSubstringIgnoreCase(tag, query))
+      item.tags?.some(
+        (tag) => getLastIndexOfSubstringIgnoreCase(tag, query) >= 0
+      )
   );
 
 export const shouldShowDropdown = (
@@ -34,7 +36,6 @@ export const shouldShowDropdown = (
   let showDropdown = false;
   if (trimmed && !selected && trimmed.length >= minCharsToShowDropdown) {
     const found = filter ? filterOptions(data, trimmed) : data;
-    console.log(data, found);
     showDropdown = found.length > 0;
   }
   return showDropdown;
@@ -81,7 +82,6 @@ const Autocomplete = ({
   const [hoverIndex, setHoverIndex] = useState(-1);
   const [selected, setSelected] = useState(false);
 
-  console.log(data);
   useEffect(() => {
     setTextInputValue(value);
   }, [value]);

--- a/src/components/autocomplete.tsx
+++ b/src/components/autocomplete.tsx
@@ -18,7 +18,9 @@ import '../styles/components/autocomplete.scss';
 
 export const filterOptions = (items: AutocompleteItemType[], query: string) =>
   items.filter(
-    (item) => getLastIndexOfSubstringIgnoreCase(item.pathLabel, query) >= 0
+    (item) =>
+      getLastIndexOfSubstringIgnoreCase(item.pathLabel, query) >= 0 ||
+      item.tags?.some((tag) => getLastIndexOfSubstringIgnoreCase(tag, query))
   );
 
 export const shouldShowDropdown = (
@@ -32,6 +34,7 @@ export const shouldShowDropdown = (
   let showDropdown = false;
   if (trimmed && !selected && trimmed.length >= minCharsToShowDropdown) {
     const found = filter ? filterOptions(data, trimmed) : data;
+    console.log(data, found);
     showDropdown = found.length > 0;
   }
   return showDropdown;
@@ -78,6 +81,7 @@ const Autocomplete = ({
   const [hoverIndex, setHoverIndex] = useState(-1);
   const [selected, setSelected] = useState(false);
 
+  console.log(data);
   useEffect(() => {
     setTextInputValue(value);
   }, [value]);

--- a/src/components/tree-select.tsx
+++ b/src/components/tree-select.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useState, useEffect } from 'react';
+import { ReactNode, useCallback, useState, useEffect, useMemo } from 'react';
 import cn from 'classnames';
 import { Except } from 'type-fest';
 
@@ -9,7 +9,7 @@ import Autocomplete from './autocomplete';
 import {
   BasicItem,
   getNodePaths,
-  restructureFlattenedTreeDataForAutocomplete,
+  prepareTreeDataForAutocomplete,
   getSingleChildren,
 } from '../utils';
 
@@ -69,6 +69,10 @@ const TreeSelect = <Item extends BasicItem<Item>>({
   const [autocompleteShowDropdown, setAutocompleteShowDropdown] =
     useState(false);
 
+  const autocompleteData = useMemo(
+    () => prepareTreeDataForAutocomplete(getNodePaths(data)),
+    [data]
+  );
   const toggleNode = useCallback(
     (node: AutocompleteItemType | BasicItem<Item>) =>
       setOpenNodes((openNodes) =>
@@ -142,20 +146,14 @@ const TreeSelect = <Item extends BasicItem<Item>>({
     ),
     [activeNodes, handleNodeClick, openNodes]
   );
-  console.log(
-    data,
-    getNodePaths(data),
-    restructureFlattenedTreeDataForAutocomplete(getNodePaths(data))
-  );
+
   return (
     <DropdownButton label={label || 'Select'} {...props}>
       {(setShowDropdownMenu: SetShowDropdownMenu) => (
         <>
           {autocomplete && (
             <Autocomplete
-              data={restructureFlattenedTreeDataForAutocomplete(
-                getNodePaths(data)
-              )}
+              data={autocompleteData}
               onDropdownChange={setAutocompleteShowDropdown}
               onSelect={(node: AutocompleteItemType | string) =>
                 handleNodeClick(node, setShowDropdownMenu)

--- a/src/components/tree-select.tsx
+++ b/src/components/tree-select.tsx
@@ -96,9 +96,10 @@ const TreeSelect = <Item extends BasicItem<Item>>({
         toggleNode(node);
       } else {
         const path = getNodePaths(data, node.id)[0];
+        const leafNode = path[path.length - 1];
         setActiveNodes(path.map((d) => d.id));
         setOpenNodes(path.map((d) => d.id));
-        onSelect(node);
+        onSelect(leafNode);
         setShowDropdownMenu(false);
       }
     },

--- a/src/components/tree-select.tsx
+++ b/src/components/tree-select.tsx
@@ -8,7 +8,7 @@ import Autocomplete from './autocomplete';
 
 import {
   BasicItem,
-  getFlattenedPaths,
+  getNodePaths,
   restructureFlattenedTreeDataForAutocomplete,
   getSingleChildren,
 } from '../utils';
@@ -25,7 +25,7 @@ export type TreeSelectProps<Item extends BasicItem<Item>> = {
   /**
    * What happens when something is selected
    */
-  onSelect: (item: Omit<Item, 'items'>) => void;
+  onSelect: (item: BasicItem<Item> | AutocompleteItemType) => void;
   /**
    * Contains autocomplete functionality to search through tree
    */
@@ -91,11 +91,10 @@ const TreeSelect = <Item extends BasicItem<Item>>({
       if (node.items) {
         toggleNode(node);
       } else {
-        const path = getFlattenedPaths(data, node.id)[0];
-        const leafNode = path[path.length - 1];
+        const path = getNodePaths(data, node.id)[0];
         setActiveNodes(path.map((d) => d.id));
         setOpenNodes(path.map((d) => d.id));
-        onSelect(leafNode);
+        onSelect(node);
         setShowDropdownMenu(false);
       }
     },
@@ -143,7 +142,11 @@ const TreeSelect = <Item extends BasicItem<Item>>({
     ),
     [activeNodes, handleNodeClick, openNodes]
   );
-
+  console.log(
+    data,
+    getNodePaths(data),
+    restructureFlattenedTreeDataForAutocomplete(getNodePaths(data))
+  );
   return (
     <DropdownButton label={label || 'Select'} {...props}>
       {(setShowDropdownMenu: SetShowDropdownMenu) => (
@@ -151,7 +154,7 @@ const TreeSelect = <Item extends BasicItem<Item>>({
           {autocomplete && (
             <Autocomplete
               data={restructureFlattenedTreeDataForAutocomplete(
-                getFlattenedPaths(data)
+                getNodePaths(data)
               )}
               onDropdownChange={setAutocompleteShowDropdown}
               onSelect={(node: AutocompleteItemType | string) =>

--- a/src/components/tree-select.tsx
+++ b/src/components/tree-select.tsx
@@ -25,7 +25,7 @@ export type TreeSelectProps<Item extends BasicItem<Item>> = {
   /**
    * What happens when something is selected
    */
-  onSelect: (item: BasicItem<Item> | AutocompleteItemType) => void;
+  onSelect: (item: Omit<Item, 'items'>) => void;
   /**
    * Contains autocomplete functionality to search through tree
    */

--- a/src/mock-data/tree-data.ts
+++ b/src/mock-data/tree-data.ts
@@ -1,13 +1,9 @@
-import {
-  getNodePaths,
-  restructureFlattenedTreeDataForAutocomplete,
-} from '../utils';
+import { getNodePaths, prepareTreeDataForAutocomplete } from '../utils';
 
 export const treeData = [
   {
     label: 'Item 1',
     id: 'item_1',
-    tags: ['tag1'],
     items: [
       {
         label: 'Item 1a',
@@ -26,6 +22,7 @@ export const treeData = [
             id: 'item_1b_B',
           },
         ],
+        tags: ['tag2', 'tag3'],
       },
     ],
   },
@@ -44,7 +41,6 @@ export const treeData = [
           {
             label: 'Item 3a A',
             id: 'item_3a_A',
-            tags: ['tag2', 'tag3'],
           },
           {
             label: 'Item 3a B',
@@ -57,5 +53,4 @@ export const treeData = [
 ];
 
 const flatPaths = getNodePaths(treeData);
-export const flattenedPaths =
-  restructureFlattenedTreeDataForAutocomplete(flatPaths);
+export const flattenedPaths = prepareTreeDataForAutocomplete(flatPaths);

--- a/src/mock-data/tree-data.ts
+++ b/src/mock-data/tree-data.ts
@@ -1,5 +1,5 @@
 import {
-  getFlattenedPaths,
+  getNodePaths,
   restructureFlattenedTreeDataForAutocomplete,
 } from '../utils';
 
@@ -7,6 +7,7 @@ export const treeData = [
   {
     label: 'Item 1',
     id: 'item_1',
+    tags: ['tag1'],
     items: [
       {
         label: 'Item 1a',
@@ -43,6 +44,7 @@ export const treeData = [
           {
             label: 'Item 3a A',
             id: 'item_3a_A',
+            tags: ['tag2', 'tag3'],
           },
           {
             label: 'Item 3a B',
@@ -54,6 +56,6 @@ export const treeData = [
   },
 ];
 
-const flatPaths = getFlattenedPaths(treeData);
+const flatPaths = getNodePaths(treeData);
 export const flattenedPaths =
   restructureFlattenedTreeDataForAutocomplete(flatPaths);

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,3 +1,5 @@
+import { AutocompleteItemType } from './components/autocomplete-item';
+
 export function getLastIndexOfSubstringIgnoreCase(
   string: string,
   substring: string
@@ -17,7 +19,7 @@ export const getNodePaths = <Item extends BasicItem<Item>>(
   id?: string,
   path: Item[] = []
 ) => {
-  let flattened: Omit<Item, 'items'>[][] = [];
+  let nodePaths: Omit<Item, 'items'>[][] = [];
   items.forEach((node) => {
     const { items, ...thisNode } = node;
     const nodePath = [...path, thisNode];
@@ -27,24 +29,30 @@ export const getNodePaths = <Item extends BasicItem<Item>>(
         'items'
       >[][];
       if (result.length) {
-        flattened = [...flattened, ...result];
+        nodePaths = [...nodePaths, ...result];
       }
     } else if (!id || thisNode.id === id) {
-      flattened = [...flattened, nodePath];
+      nodePaths = [...nodePaths, nodePath];
     }
   });
-  return flattened;
+  return nodePaths;
 };
 
-export function restructureFlattenedTreeDataForAutocomplete<
-  Item extends BasicItem<Item>
->(flattenedTreeData: Item[][]) {
-  return flattenedTreeData.map((items) => ({
-    id: items[items.length - 1].id,
-    pathLabel: items.map((item) => item.label).join(' / '),
-    itemLabel: items[items.length - 1].label,
-    tags: items[items.length - 1].tags,
-  }));
+export function prepareTreeDataForAutocomplete<Item extends BasicItem<Item>>(
+  flattenedTreeData: Item[][]
+) {
+  return flattenedTreeData.map((items) => {
+    const autocompleteItem: AutocompleteItemType = {
+      id: items[items.length - 1].id,
+      pathLabel: items.map((item) => item.label).join(' / '),
+      itemLabel: items[items.length - 1].label,
+    };
+    const tags = items.flatMap((item) => item.tags || []);
+    if (tags.length) {
+      autocompleteItem.tags = tags;
+    }
+    return autocompleteItem;
+  });
 }
 
 export function* getSingleChildren<Item extends BasicItem<Item>>(

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -8,20 +8,21 @@ export function getLastIndexOfSubstringIgnoreCase(
 export type BasicItem<Item> = {
   label: string;
   id: string;
+  tags?: string[];
   items?: BasicItem<Item>[];
 };
 
-export const getFlattenedPaths = <Item extends BasicItem<Item>>(
-  currentItems: Item[],
+export const getNodePaths = <Item extends BasicItem<Item>>(
+  items: Item[],
   id?: string,
   path: Item[] = []
 ) => {
   let flattened: Omit<Item, 'items'>[][] = [];
-  currentItems.forEach((node) => {
+  items.forEach((node) => {
     const { items, ...thisNode } = node;
     const nodePath = [...path, thisNode];
     if (items) {
-      const result = getFlattenedPaths(items, id, nodePath) as Omit<
+      const result = getNodePaths(items, id, nodePath) as Omit<
         Item,
         'items'
       >[][];
@@ -35,22 +36,15 @@ export const getFlattenedPaths = <Item extends BasicItem<Item>>(
   return flattened;
 };
 
-export function restructureFlattenedTreeItemsForAutocomplete<
-  Item extends BasicItem<Item>
->(items: Item[], sep = ' / ') {
-  return {
-    id: items[items.length - 1].id,
-    pathLabel: items.map((item) => item.label).join(sep),
-    itemLabel: items[items.length - 1].label,
-  };
-}
-
 export function restructureFlattenedTreeDataForAutocomplete<
   Item extends BasicItem<Item>
 >(flattenedTreeData: Item[][]) {
-  return flattenedTreeData.map((items) =>
-    restructureFlattenedTreeItemsForAutocomplete(items)
-  );
+  return flattenedTreeData.map((items) => ({
+    id: items[items.length - 1].id,
+    pathLabel: items.map((item) => item.label).join(' / '),
+    itemLabel: items[items.length - 1].label,
+    tags: items[items.length - 1].tags,
+  }));
 }
 
 export function* getSingleChildren<Item extends BasicItem<Item>>(


### PR DESCRIPTION
## Purpose
In the tree select for field names there are some fields which need to be found by text which is not in the field name. To deal with this an additional attribute `tags` has been created which is an array of text which can be matched against. This PR accommodates the `tags` attribute.

## Approach

- Include tags when finding matching nodes
- Renamed a few things to make it clearer what they do
- CI tests failing because of not having merging against the latest target branch so fixed this

## Testing

- Added unit tests
- Linked to uniprot-website's main branch and works

## Stories
Not updated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
