### PR TITLE
parametrise the minimum length for the sequence validation

### DIFF
--- a/src/components/sequence-submission.tsx
+++ b/src/components/sequence-submission.tsx
@@ -24,6 +24,10 @@ type Props = {
    * Display text when the textarea is empty.
    */
   placeholder?: string;
+  /**
+   * Minimum acceptable length for a sequence
+   */
+  minimumLength?: number;
 };
 
 const SequenceSubmission = ({
@@ -31,18 +35,19 @@ const SequenceSubmission = ({
   onChange,
   placeholder,
   defaultValue,
+  minimumLength,
 }: Props) => {
   const [processed, setProcessed] = useState<SequenceObject[]>([]);
 
   const onChangeWithValidation = useCallback(
     (newValue) => {
-      const processed = sequenceProcessor(newValue);
+      const processed = sequenceProcessor(newValue, minimumLength);
       setProcessed(processed);
 
       // Calling the custom 'onChange' callback first
       onChange?.(processed);
     },
-    [onChange]
+    [onChange, minimumLength]
   );
 
   useEffect(() => {

--- a/src/sequence-utils/__test__/sequenceValidator.spec.ts
+++ b/src/sequence-utils/__test__/sequenceValidator.spec.ts
@@ -50,13 +50,13 @@ describe('validateSequences', () => {
     expect(results).toEqual([errorResponses.missingSequence]);
   });
 
-  it('should fail if a sequence is too short', () => {
-    results = validateSequences([shortSequence]);
+  it('should fail if a sequence is "too short"', () => {
+    results = validateSequences([shortSequence], 11);
     expect(results).toEqual([errorResponses.shortSequence]);
   });
 
   it('should NOT fail if a sequence is too short after clean-up', () => {
-    results = validateSequences([shortSequenceAfterCleanUp]);
+    results = validateSequences([shortSequenceAfterCleanUp], 11);
     expectedResult = [
       {
         ...validResponse,

--- a/src/sequence-utils/sequence-processor.ts
+++ b/src/sequence-utils/sequence-processor.ts
@@ -20,12 +20,18 @@ const getNewSequenceObject = (): SequenceObject => ({
   sequence: '',
 });
 
-const validate = (sequenceObject: SequenceObject): SequenceObject => {
-  const validation = sequenceValidator(sequenceObject.sequence);
+const validate = (
+  sequenceObject: SequenceObject,
+  minimumLength?: number
+): SequenceObject => {
+  const validation = sequenceValidator(sequenceObject.sequence, minimumLength);
   return { ...validation, ...sequenceObject };
 };
 
-const sequenceProcessor = (rawText: string): SequenceObject[] => {
+const sequenceProcessor = (
+  rawText: string,
+  minimumLength?: number
+): SequenceObject[] => {
   const sequences: SequenceObject[] = [];
   let currentSequence = getNewSequenceObject();
   for (const line of rawText.split('\n')) {
@@ -37,7 +43,7 @@ const sequenceProcessor = (rawText: string): SequenceObject[] => {
       if (currentSequence.sequence) {
         // if we already have sequence data being processed
         // store current sequence
-        sequences.push(validate(currentSequence));
+        sequences.push(validate(currentSequence, minimumLength));
 
         // and start new sequence
         currentSequence = getNewSequenceObject();

--- a/src/sequence-utils/sequenceValidator.ts
+++ b/src/sequence-utils/sequenceValidator.ts
@@ -175,7 +175,7 @@ export function findLikelyType(sequence: string) {
  * @param {string} sequence - A sequence
  * @return {object} The result
  */
-export function sequenceValidator(sequence: string) {
+export function sequenceValidator(sequence: string, minimumLength?: number) {
   // Sequence was not passed at all
   if (!sequence) {
     return errorResponses.missingSequence;
@@ -198,9 +198,7 @@ export function sequenceValidator(sequence: string) {
   if (!cleanSequence) {
     return errorResponses.missingSequence;
   }
-
-  // Minimum length from: https://www.ebi.ac.uk/ipd/imgt/hla/blast.html
-  if (cleanSequence.length < 11) {
+  if (minimumLength && cleanSequence.length <= minimumLength) {
     return errorResponses.shortSequence;
   }
 
@@ -233,7 +231,7 @@ export function sequenceValidator(sequence: string) {
  * @return {Array<object|null>} The result of validating each sequence
  * while keeping order intact.
  */
-function validateSequences(input: string | string[]) {
+function validateSequences(input: string | string[], minimumLength?: number) {
   let sequences: string[] = [];
   // Is this a string?
   if (typeof input === 'string') {
@@ -268,7 +266,9 @@ function validateSequences(input: string | string[]) {
   }
 
   // Validate each sequence separately, compile and return the results
-  return sequences.map((sequence) => sequenceValidator(sequence));
+  return sequences.map((sequence) =>
+    sequenceValidator(sequence, minimumLength)
+  );
 }
 
 export default validateSequences;


### PR DESCRIPTION
## Purpose
Remove the hardcoded minimum limit for the sequence validation in order to accept smaller sequences

## Approach
Make an optionnal parameter for it, expose it through the helper functions and components using them.

## Testing
Updated tests

## Stories
-

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
