### PR TITLE
refactor cards

### DIFF
--- a/src/components/__tests__/__snapshots__/card.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/card.spec.tsx.snap
@@ -64,37 +64,3 @@ exports[`Card component should render card with links 1`] = `
   </section>
 </DocumentFragment>
 `;
-
-exports[`Card component should render card with target 1`] = `
-<DocumentFragment>
-  <section
-    class="card card--has-link"
-  >
-    <a
-      aria-hidden="true"
-      class="card__link"
-      data-testid="background-link"
-      href="/target"
-      tabindex="-1"
-    />
-    <div
-      class="card__container"
-    >
-      <div
-        class="card__header card__header--with-separator"
-      >
-        <h2>
-          Title
-        </h2>
-      </div>
-      <div
-        class="card__content"
-      >
-        <span>
-          Some content
-        </span>
-      </div>
-    </div>
-  </section>
-</DocumentFragment>
-`;

--- a/src/components/__tests__/__snapshots__/data-list.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/data-list.spec.tsx.snap
@@ -2,60 +2,60 @@
 
 exports[`DataList should render autoload 1`] = `
 <DocumentFragment>
-  <div
-    class="data-list"
+  <ul
+    class="data-list no-bullet"
   >
-    <section>
+    <li>
       <p>
         0
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         1
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         2
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         3
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         4
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         5
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         6
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         7
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         8
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         9
       </p>
-    </section>
-  </div>
+    </li>
+  </ul>
   <div
     class="data-loader__loading"
   >
@@ -72,60 +72,60 @@ exports[`DataList should render autoload 1`] = `
 
 exports[`DataList should render click-to-load 1`] = `
 <DocumentFragment>
-  <div
-    class="data-list"
+  <ul
+    class="data-list no-bullet"
   >
-    <section>
+    <li>
       <p>
         0
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         1
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         2
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         3
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         4
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         5
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         6
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         7
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         8
       </p>
-    </section>
-    <section>
+    </li>
+    <li>
       <p>
         9
       </p>
-    </section>
-  </div>
+    </li>
+  </ul>
   <div
     class="data-loader__loading"
   >

--- a/src/components/__tests__/card.spec.tsx
+++ b/src/components/__tests__/card.spec.tsx
@@ -1,5 +1,3 @@
-import { screen, fireEvent } from '@testing-library/react';
-
 import Card from '../card';
 
 import renderWithRouter from '../../testHelpers/renderWithRouter';
@@ -29,16 +27,5 @@ describe('Card component', () => {
       </Card>
     );
     expect(asFragment()).toMatchSnapshot();
-  });
-
-  it('should render card with target', () => {
-    const { asFragment, history } = renderWithRouter(
-      <Card header={<h2>Title</h2>} to="/target">
-        <span>Some content</span>
-      </Card>
-    );
-    expect(asFragment()).toMatchSnapshot();
-    fireEvent.click(screen.getByTestId('background-link'));
-    expect(history.location.pathname).toBe('/target');
   });
 });

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, FC, ReactNode, HTMLAttributes, ReactText } from 'react';
-import { NavLink, Link, LinkProps } from 'react-router-dom';
+import { NavLink, LinkProps } from 'react-router-dom';
 import cn from 'classnames';
 
 import '../styles/components/card.scss';
@@ -42,41 +42,14 @@ type Props = {
    * Links to be displayed at the bottom of the card
    */
   links?: Array<CardActionProps>;
-  /**
-   * Target/link of the card when clicking on it
-   */
-  to?: LinkProps['to'];
 };
 
 const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
   (
-    {
-      header,
-      headerSeparator = true,
-      children,
-      links,
-      to,
-      className,
-      ...props
-    },
+    { header, headerSeparator = true, children, links, className, ...props },
     ref
   ) => (
-    <section
-      className={cn(className, 'card', {
-        'card--has-link': to,
-      })}
-      ref={ref}
-      {...props}
-    >
-      {to && (
-        <Link
-          data-testid="background-link"
-          to={to}
-          className="card__link"
-          aria-hidden="true"
-          tabIndex={-1}
-        />
-      )}
+    <section className={cn(className, 'card')} ref={ref} {...props}>
       <div className="card__container">
         {header && (
           <div
@@ -87,7 +60,7 @@ const Card = forwardRef<HTMLElement, Props & HTMLAttributes<HTMLElement>>(
             {header}
           </div>
         )}
-        <div className="card__content">{children}</div>
+        {children && <div className="card__content">{children}</div>}
       </div>
       {links?.length ? (
         <div className="card__actions">

--- a/src/components/data-list.tsx
+++ b/src/components/data-list.tsx
@@ -65,7 +65,7 @@ const DataListItem = <Datum extends BasicDatum>({
     }
   }
 
-  return <section key={id}>{rendered}</section>;
+  return <li key={id}>{rendered}</li>;
 };
 const MemoizedDataListItem = memo(DataListItem) as typeof DataListItem;
 
@@ -77,13 +77,13 @@ export const DataList = <Datum extends BasicDatum>({
   onSelectionChange,
   className,
   ...props
-}: Props<Datum> & HTMLAttributes<HTMLDivElement>) => {
+}: Props<Datum> & HTMLAttributes<HTMLUListElement>) => {
   const { checkboxContainerRef } = useDataCheckboxes(onSelectionChange);
 
   return (
-    <div
+    <ul
       {...props}
-      className={cn('data-list', className)}
+      className={cn('data-list', 'no-bullet', className)}
       ref={checkboxContainerRef}
     >
       {data.map((datum, index) => {
@@ -99,7 +99,7 @@ export const DataList = <Datum extends BasicDatum>({
           />
         );
       })}
-    </div>
+    </ul>
   );
 };
 

--- a/src/hooks/useDataCheckboxes.ts
+++ b/src/hooks/useDataCheckboxes.ts
@@ -50,9 +50,9 @@ const useDataCheckboxes = (
 ) => {
   // HTML elements refs
   const privateSelectAllRef = useRef<HTMLInputElement | null>(null);
-  const privateCheckboxContainerRef = useRef<HTMLTableSectionElement | null>(
-    null
-  );
+  const privateCheckboxContainerRef = useRef<
+    HTMLTableSectionElement | HTMLUListElement | null
+  >(null);
   const lastTickedRef = useRef<HTMLInputElement | null>(null);
 
   // Bind click event to native event on select-all checkbox
@@ -91,7 +91,7 @@ const useDataCheckboxes = (
 
   // Bind click event to native event using event delegation on container
   const checkboxContainerRef = useCallback(
-    (checkboxContainer: HTMLTableSectionElement | null) => {
+    (checkboxContainer: HTMLTableSectionElement | HTMLUListElement | null) => {
       privateCheckboxContainerRef.current = checkboxContainer;
       if (!(onSelectionChange && checkboxContainer)) {
         return;

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -13,50 +13,22 @@ $card-link-padding: 0.5rem;
   width: calc(100% - #{$global-padding});
   position: relative;
 
-  &__link {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    cursor: pointer;
-  }
-
-  &__container,
-  &__actions {
-    position: relative;
-  }
-
-  &--has-link {
-    transition: 0.5s background-color ease;
-
-    &:hover,
-    &:focus-within {
-      background-color: scale-color($color: $colour-platinum, $lightness: 40%);
-    }
-
-    * {
-      pointer-events: none;
-    }
-
-    a,
-    button,
-    input,
-    label {
-      pointer-events: initial;
-    }
-  }
-
-  &__content {
+  &__container {
     padding: $global-padding;
+    padding-block: 0.5 * $global-padding;
   }
 
   &__header {
     display: flex;
     align-items: baseline;
-    padding-left: $global-padding;
+    position: relative;
 
-    &--with-separator {
+    &--with-separator::after {
+      content: '';
+      position: absolute;
+      left: -$global-padding;
+      right: -$global-padding;
+      bottom: 0;
       border-bottom: 0.125rem solid $colour-platinum;
     }
 

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -68,7 +68,6 @@ export const Card = () => {
         ) : undefined
       }
       headerSeparator={hasHeaderSeparator}
-      to={boolean('to', false, 'Props') ? '#' : undefined}
       links={boolean('links', false, 'Props') ? links : undefined}
     >
       {getLipsumSentences()}


### PR DESCRIPTION
## Purpose
Refactor `Card`s to covers the needs of https://www.ebi.ac.uk/panda/jira/browse/TRM-26829 & https://www.ebi.ac.uk/panda/jira/browse/TRM-27053

## Approach
 - Remove `to` from props as we decided that a card doesn't need to be clickable and should contain a link within if needed. Remove corresponding logic and styling workarounds
 - Change `DataList` in order to change it from a `div` containing `section`s to a `ul` containing `li`s. More semantic, and also, we mainly use it with `Card`s that are themselves sections already so it was causing 2 sections to be rendered one directly within the other

## Testing
Updated tests, no new tests as less logic than before

## Stories
Card

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
