### PR TITLE
allow to open groups of ellipsis reveals in group

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 81.09,
-        "statements": 80.66,
+        "lines": 80.97,
+        "statements": 80.55,
         "functions": 78.93,
         "branches": 70.52
       }

--- a/src/components/ellipsis-reveal.tsx
+++ b/src/components/ellipsis-reveal.tsx
@@ -1,24 +1,57 @@
-import { useState, HTMLAttributes, PropsWithChildren } from 'react';
+import {
+  useState,
+  HTMLAttributes,
+  PropsWithChildren,
+  createContext,
+  FC,
+  SetStateAction,
+  Dispatch,
+  useContext,
+} from 'react';
 import cn from 'classnames';
 
 import { Button } from './button';
 
 import '../styles/components/ellipsis-reveal.scss';
 
+const Context = createContext<
+  null | [Set<string>, Dispatch<SetStateAction<Set<string>>>]
+>(null);
+Context.displayName = 'EllipsisRevealContext';
+
+const Provider: FC = ({ children }) => {
+  const state = useState(new Set<string>());
+
+  return <Context.Provider value={state}>{children}</Context.Provider>;
+};
+
 const EllipsisReveal = ({
   children,
   className,
   title,
+  contextKey,
   ...props
-}: PropsWithChildren<HTMLAttributes<HTMLButtonElement>>) => {
+}: PropsWithChildren<
+  HTMLAttributes<HTMLButtonElement> & { contextKey?: string }
+>) => {
+  const contextState = useContext(Context);
+  const openFromContext =
+    contextState && contextKey && contextState[0].has(contextKey);
   const [open, setOpen] = useState(false);
-  if (open) {
+  if (open || openFromContext) {
     return <>{children}</>;
   }
   return (
     <Button
       variant="tertiary"
-      onClick={() => setOpen(true)}
+      onClick={() => {
+        setOpen(true);
+        if (contextKey && contextState) {
+          contextState[1](
+            (previousSet) => new Set([...previousSet, contextKey])
+          );
+        }
+      }}
       className={cn(className, 'ellipsis-reveal')}
       title={title || 'Show more'}
       aria-expanded="false"
@@ -28,5 +61,7 @@ const EllipsisReveal = ({
     </Button>
   );
 };
+
+EllipsisReveal.Provider = Provider;
 
 export default EllipsisReveal;

--- a/stories/EllipsisReveal.stories.tsx
+++ b/stories/EllipsisReveal.stories.tsx
@@ -15,8 +15,25 @@ export default {
   },
 };
 
-export const expandableList = () => (
+export const ellipsisReveal = () => (
   <>
     Some text <EllipsisReveal>{getLipsumSentences()}</EllipsisReveal>
   </>
+);
+
+export const ellipsisRevealInGroup = () => (
+  <EllipsisReveal.Provider>
+    <p>
+      Some text{' '}
+      <EllipsisReveal contextKey="group">{getLipsumSentences()}</EllipsisReveal>
+    </p>
+    <p>
+      Some other text{' '}
+      <EllipsisReveal contextKey="group">{getLipsumSentences()}</EllipsisReveal>
+    </p>
+    <p>
+      Some other text again{' '}
+      <EllipsisReveal contextKey="group">{getLipsumSentences()}</EllipsisReveal>
+    </p>
+  </EllipsisReveal.Provider>
 );


### PR DESCRIPTION
## Purpose
Be able to expand all EllipsisReveal components defined as part of the same group https://www.ebi.ac.uk/panda/jira/browse/TRM-27938

## Approach
Use a context that need to be set above all the controlled EllipsisReveal components, use a key in order to define sub-groups. the state in the context will override the local state

## Testing
manual testing in new story

## Stories
ellipsis reveal stories

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
