### PR TITLE
Bytes number

### DIFF
--- a/src/__tests__/utils.spec.tsx
+++ b/src/__tests__/utils.spec.tsx
@@ -209,9 +209,11 @@ describe('formatLargeNumber', () => {
 
 describe('formatBytesNumber', () => {
   it.each([
+    [0, 0, '0 Bytes'],
     [1, 1, '1 Bytes'],
     [2000, 1, '2 KB'],
     [30000, 1, '29.3 KB'],
+    [30000, -1, '29 KB'],
     [400000, 1, '390.6 KB'],
     [4372255, 1, '4.2 MB'], // Source macOS: ls -l vs ls -lh
     [5000000, 1, '4.8 MB'],

--- a/src/__tests__/utils.spec.tsx
+++ b/src/__tests__/utils.spec.tsx
@@ -4,6 +4,8 @@ import {
   prepareTreeDataForAutocomplete,
   getSingleChildren,
   tidyUrlString,
+  formatLargeNumber,
+  formatBytesNumber,
 } from '../utils';
 
 import { treeData } from '../mock-data/tree-data';
@@ -190,4 +192,43 @@ describe('tidyUrlString', () => {
   it('should handle a schema-relative URL', () => {
     expect(tidyUrlString('//www.ebi.ac.uk/')).toEqual('www.ebi.ac.uk');
   });
+});
+
+describe('formatLargeNumber', () => {
+  it.each([
+    [1000, '1,000'],
+    [-1000, '-1,000'],
+    [999, '999'],
+    [1000.0001, '1,000.0001'],
+    [999.0001, '999.0001'],
+    [0.0000001, '1e-7'],
+  ])('.formatLargeNumber(%p)', (input: number, expected: string) => {
+    expect(formatLargeNumber(input)).toBe(expected);
+  });
+});
+
+describe('formatBytesNumber', () => {
+  it.each([
+    [1, 1, '1 Bytes'],
+    [2000, 1, '2 KB'],
+    [30000, 1, '29.3 KB'],
+    [400000, 1, '390.6 KB'],
+    [4372255, 1, '4.2 MB'], // Source macOS: ls -l vs ls -lh
+    [5000000, 1, '4.8 MB'],
+    [60000000, 1, '57.2 MB'],
+    [700000000, 1, '667.6 MB'],
+    [2621388791, 1, '2.4 GB'], // Source macOS: ls -l vs ls -lh
+    [8000000000, 1, '7.5 GB'],
+    [90000000000, 1, '83.8 GB'],
+    [100000000000, 1, '93.1 GB'],
+    [1100000000000, 1, '1 TB'],
+    [12000000000000, 1, '10.9 TB'],
+    [130000000000000, 1, '118.2 TB'],
+    [1e30, 4, '827,180.6126 YB'], // If bigger than available prefix then use thousands
+  ])(
+    '.formatBytesNumber(%p, %p)',
+    (bytes: number, decimals: number, expected: string) => {
+      expect(formatBytesNumber(bytes, decimals)).toBe(expected);
+    }
+  );
 });

--- a/src/__tests__/utils.spec.tsx
+++ b/src/__tests__/utils.spec.tsx
@@ -200,9 +200,10 @@ describe('formatLargeNumber', () => {
     [-1000, '-1,000'],
     [999, '999'],
     [1000.0001, '1,000.0001'],
+    ['1000.0001', '1,000.0001'],
     [999.0001, '999.0001'],
     [0.0000001, '1e-7'],
-  ])('.formatLargeNumber(%p)', (input: number, expected: string) => {
+  ])('.formatLargeNumber(%p)', (input: string | number, expected: string) => {
     expect(formatLargeNumber(input)).toBe(expected);
   });
 });
@@ -213,6 +214,7 @@ describe('formatBytesNumber', () => {
     [1, 1, '1 Bytes'],
     [2000, 1, '2 KB'],
     [30000, 1, '29.3 KB'],
+    ['30000', 1, '29.3 KB'],
     [30000, -1, '29 KB'],
     [400000, 1, '390.6 KB'],
     [4372255, 1, '4.2 MB'], // Source macOS: ls -l vs ls -lh
@@ -229,7 +231,7 @@ describe('formatBytesNumber', () => {
     [1e30, 4, '827,180.6126 YB'], // If bigger than available prefix then use thousands
   ])(
     '.formatBytesNumber(%p, %p)',
-    (bytes: number, decimals: number, expected: string) => {
+    (bytes: string | number, decimals: number, expected: string) => {
       expect(formatBytesNumber(bytes, decimals)).toBe(expected);
     }
   );

--- a/src/components/__tests__/__snapshots__/bytes-number.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/bytes-number.spec.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bytes number component should render 1`] = `
+<DocumentFragment>
+  2.4 GB
+</DocumentFragment>
+`;

--- a/src/components/__tests__/bytes-number.spec.tsx
+++ b/src/components/__tests__/bytes-number.spec.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+
+import { BytesNumber } from '..';
+
+describe('Bytes number component', () => {
+  it('should render', () => {
+    const { asFragment } = render(
+      <BytesNumber decimals={1}>{2621388791}</BytesNumber>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/long-number.spec.tsx
+++ b/src/components/__tests__/long-number.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 
-import LongNumber from '../long-number';
+import { LongNumber } from '..';
 
 describe('Long number component', () => {
   it('should render', () => {

--- a/src/components/bytes-number.tsx
+++ b/src/components/bytes-number.tsx
@@ -1,0 +1,15 @@
+import { formatBytesNumber } from '../utils';
+
+type Props = {
+  /**
+   * The number to format
+   */
+  children: string | number;
+  decimals?: number;
+};
+
+const BytesNumber = ({ children, decimals = 0 }: Props) => (
+  <>{formatBytesNumber(children, decimals)}</>
+);
+
+export default BytesNumber;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@
 export { default as Accordion } from './accordion';
 export { default as AccordionSearch } from './accordion-search';
 export { default as Autocomplete } from './autocomplete';
+export { default as BytesNumber } from './bytes-number';
 export { default as Bubble } from './bubble';
 export { default as Button } from './button';
 export { default as ButtonModal } from './button-modal';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,10 +2,10 @@
 export { default as Accordion } from './accordion';
 export { default as AccordionSearch } from './accordion-search';
 export { default as Autocomplete } from './autocomplete';
-export { default as BytesNumber } from './bytes-number';
 export { default as Bubble } from './bubble';
 export { default as Button } from './button';
 export { default as ButtonModal } from './button-modal';
+export { default as BytesNumber } from './bytes-number';
 export { default as Card } from './card';
 export { default as Chip } from './chip';
 export { default as CodeBlock } from './code-block';

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -69,7 +69,37 @@ export function* getSingleChildren<Item extends BasicItem<Item>>(
 }
 
 export function formatLargeNumber(x: string | number) {
-  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const string = x.toString();
+
+  // If number is converted to scientific notation return as is
+  // because commas can't be added as the coefficient will be < 10
+  if (string.includes('e')) {
+    return string;
+  }
+  const [integer, decimal] = x.toString().split('.');
+  const integerWithCommas = integer.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return [integerWithCommas, decimal]
+    .filter((el) => typeof el !== 'undefined')
+    .join('.');
+}
+
+export function formatBytesNumber(bytes: string | number, decimals = 0) {
+  const bytesNumber = +bytes;
+  if (!bytesNumber) {
+    return '0 Bytes';
+  }
+  const positiveDecimals = decimals < 0 ? 0 : decimals;
+  const baseFactor = 1024;
+  const prefixes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const prefixesIndex = Math.min(
+    Math.floor(Math.log(bytesNumber) / Math.log(baseFactor)),
+    prefixes.length - 1
+  );
+  const number = (bytesNumber / baseFactor ** prefixesIndex).toFixed(
+    positiveDecimals
+  );
+  const prefix = prefixes[prefixesIndex];
+  return `${formatLargeNumber(parseFloat(number))} ${prefix}`;
 }
 
 const reProtocol = /^(https?:)?(\/\/)?/;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -90,16 +90,16 @@ export function formatBytesNumber(bytes: string | number, decimals = 0) {
   }
   const positiveDecimals = decimals < 0 ? 0 : decimals;
   const baseFactor = 1024;
-  const prefixes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-  const prefixesIndex = Math.min(
+  const units = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const unitsIndex = Math.min(
     Math.floor(Math.log(bytesNumber) / Math.log(baseFactor)),
-    prefixes.length - 1
+    units.length - 1
   );
-  const number = (bytesNumber / baseFactor ** prefixesIndex).toFixed(
+  const number = (bytesNumber / baseFactor ** unitsIndex).toFixed(
     positiveDecimals
   );
-  const prefix = prefixes[prefixesIndex];
-  return `${formatLargeNumber(parseFloat(number))} ${prefix}`;
+  const unit = units[unitsIndex];
+  return `${formatLargeNumber(parseFloat(number))} ${unit}`;
 }
 
 const reProtocol = /^(https?:)?(\/\/)?/;

--- a/stories/BytesNumber.stories.tsx
+++ b/stories/BytesNumber.stories.tsx
@@ -1,0 +1,13 @@
+import { number } from '@storybook/addon-knobs';
+
+import { BytesNumber } from '../src/components';
+
+export default {
+  title: 'Visualisation/Bytes number',
+};
+
+export const bytesNumber = () => (
+  <BytesNumber decimals={number('decimals', 0)}>
+    {number('bytes', 1024)}
+  </BytesNumber>
+);


### PR DESCRIPTION
## Purpose
We need the ability to format file sizes generated by the async downloads to bytes with prefixes.

## Approach

- Create util fn `formatBytesNumber`
- Use this util fn in the component `<BytesNumber>`
- Increased the input cases covered by `formatLargeNumber`

## Testing
- Added tests and snapshots

## Stories
- Added `<BytesNumber>` with knobs

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
