### PR TITLE
Remove query string pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "foundation-sites": "6.7.5",
     "history": "4.10.1",
     "lodash-es": "4.17.21",
-    "query-string": "7.1.1",
     "timing-functions": "2.0.1",
     "tippy.js": "6.3.7",
     "type-fest": "3.1.0",

--- a/src/components/__tests__/__snapshots__/facets.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/facets.spec.tsx.snap
@@ -241,7 +241,7 @@ exports[`<Facets /> should render multiple facets 1`] = `
             </li>
             <li>
               <a
-                href="/?facets=model_organism%3AA.%20thaliana"
+                href="/?facets=model_organism%3AA.+thaliana"
               >
                 A. thaliana (1,239)
               </a>
@@ -428,35 +428,35 @@ exports[`<Facets /> should render multiple facets 1`] = `
           >
             <li>
               <a
-                href="/?facets=length%3A%5B1%20TO%20200%5D"
+                href="/?facets=length%3A%5B1+TO+200%5D"
               >
                 1 - 200 (101,062)
               </a>
             </li>
             <li>
               <a
-                href="/?facets=length%3A%5B201%20TO%20400%5D"
+                href="/?facets=length%3A%5B201+TO+400%5D"
               >
                 201 - 400 (553,257)
               </a>
             </li>
             <li>
               <a
-                href="/?facets=length%3A%5B401%20TO%20600%5D"
+                href="/?facets=length%3A%5B401+TO+600%5D"
               >
                 401 - 600 (423,158)
               </a>
             </li>
             <li>
               <a
-                href="/?facets=length%3A%5B601%20TO%20800%5D"
+                href="/?facets=length%3A%5B601+TO+800%5D"
               >
                 601 - 800 (120,501)
               </a>
             </li>
             <li>
               <a
-                href="/?facets=length%3A%5B801%20TO%20%2A%5D"
+                href="/?facets=length%3A%5B801+TO+*%5D"
               >
                 &gt;= 801 (85,205)
               </a>

--- a/src/components/__tests__/facets.spec.tsx
+++ b/src/components/__tests__/facets.spec.tsx
@@ -73,7 +73,7 @@ const testCases: {
       facets: { identity: new Set(['1.0']) },
       query: 'glucose',
     },
-    query: 'facets=identity%3A1.0&query=glucose',
+    query: 'query=glucose&facets=identity%3A1.0',
   },
   {
     description: 'should handle facets with another name',
@@ -82,7 +82,7 @@ const testCases: {
       query: 'glucose',
     },
     key: 'filter',
-    query: 'filter=identity%3A1.0&query=glucose',
+    query: 'query=glucose&filter=identity%3A1.0',
   },
 ];
 
@@ -93,7 +93,7 @@ describe('parse facets', () => {
 });
 
 describe('stringify facets', () => {
-  test.each(testCases)('parse $description', ({ parsed, query, key }) => {
+  test.each(testCases)('stringify $description', ({ parsed, query, key }) => {
     expect(stringify(parsed, key)).toEqual(query);
   });
 });

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -25,7 +25,7 @@ export type FacetObject = {
 // To hold facets, record of sets
 type CustomQueryValue = Record<string, Set<string>>;
 // The modified query object, with our custom facet object
-type CustomParsedQuery = ParsedQuery<string | CustomQueryValue>;
+export type CustomParsedQuery = ParsedQuery<string | CustomQueryValue>;
 
 /**
  * Takes a search string and parse it, handle facets specifically, keeps them

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -43,11 +43,10 @@ export const parse = (
   ).map((stringTuple) => stringTuple.split(':'));
   const facets: CustomQueryValue = {};
   for (const [name, value] of facetTokens) {
-    if (!facets[name]) {
-      facets[name] = new Set();
-    }
-    if (facets[name] instanceof Set) {
+    if (facets[name]) {
       facets[name].add(value);
+    } else {
+      facets[name] = new Set([value]);
     }
   }
   customParsed[queryStringKey] = facets;

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -31,17 +31,16 @@ export const parse = (
   queryStringKey = 'facets'
 ): CustomParsedQuery => {
   const parsed = new URLSearchParams(string);
-  let queryStringFacet = parsed.get(queryStringKey);
+  const queryStringFacet = parsed.get(queryStringKey);
   const customParsed: CustomParsedQuery = Object.fromEntries(parsed);
   if (!queryStringFacet) {
     return customParsed;
   }
-  if (Array.isArray(queryStringFacet)) {
-    queryStringFacet = queryStringFacet.join(',');
-  }
-  const facetTokens = queryStringFacet
-    .split(',')
-    .map((stringTuple) => stringTuple.split(':'));
+  const facetTokens = (
+    Array.isArray(queryStringFacet)
+      ? queryStringFacet
+      : queryStringFacet.split(',')
+  ).map((stringTuple) => stringTuple.split(':'));
   const facets: CustomQueryValue = {};
   for (const [name, value] of facetTokens) {
     if (!facets[name]) {

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -43,11 +43,10 @@ export const parse = (
   ).map((stringTuple) => stringTuple.split(':'));
   const facets: CustomQueryValue = {};
   for (const [name, value] of facetTokens) {
-    if (facets[name]) {
-      facets[name].add(value);
-    } else {
-      facets[name] = new Set([value]);
+    if (!facets[name]) {
+      facets[name] = new Set();
     }
+    facets[name].add(value);
   }
   customParsed[queryStringKey] = facets;
   return customParsed;

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -31,8 +31,8 @@ export const parse = (
   queryStringKey = 'facets'
 ): CustomParsedQuery => {
   const parsed = new URLSearchParams(string);
-  const queryStringFacet = parsed.get(queryStringKey);
   const customParsed: CustomParsedQuery = Object.fromEntries(parsed);
+  const queryStringFacet = parsed.get(queryStringKey);
   if (!queryStringFacet) {
     return customParsed;
   }

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -36,11 +36,9 @@ export const parse = (
   if (!queryStringFacet) {
     return customParsed;
   }
-  const facetTokens = (
-    Array.isArray(queryStringFacet)
-      ? queryStringFacet
-      : queryStringFacet.split(',')
-  ).map((stringTuple) => stringTuple.split(':'));
+  const facetTokens = queryStringFacet
+    .split(',')
+    .map((stringTuple) => stringTuple.split(':'));
   const facets: CustomQueryValue = {};
   for (const [name, value] of facetTokens) {
     if (!facets[name]) {

--- a/stories/Facets.stories.tsx
+++ b/stories/Facets.stories.tsx
@@ -16,18 +16,11 @@ export default {
   },
 };
 
+const propFacetData = facetData.slice(0, 2);
+const childFacetData = facetData.slice(2);
+
 const Demo = () => {
   const location = useLocation();
-
-  const extraActionsFor = new Map([
-    [
-      'long_facet',
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a className="button tertiary expandable-list__action">
-        Link to somewhere
-      </a>,
-    ],
-  ]);
 
   return (
     <>
@@ -35,9 +28,9 @@ const Demo = () => {
         pathname: {location.pathname + location.search}
       </code>
       <div style={{ border: '1px solid black', padding: '1ch' }}>
-        <Facets data={facetData} extraActionsFor={extraActionsFor}>
+        <Facets data={propFacetData}>
           injected content
-          {facetData.map((facet) => (
+          {childFacetData.map((facet) => (
             <Facet data={facet} key={facet.name} />
           ))}
         </Facets>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8933,11 +8933,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-filter-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
-  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
-
 finalhandler@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
@@ -13772,16 +13767,6 @@ qs@6.11.0, qs@^6.10.0, qs@^6.6.0:
   dependencies:
     side-channel "^1.0.4"
 
-query-string@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
-  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -15258,11 +15243,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz#8a595135def9592bda69709474f1cbeea7c2467f"
   integrity sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -15367,11 +15347,6 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
## Purpose & Approach
[Remove the `query-string` package and in it's place utilise `URLSearchParams`.](https://www.ebi.ac.uk/panda/jira/browse/TRM-30040)

## Testing
Tested stringify and parse separately

## Stories
Removed the extra link and duplicate facets

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?