### PR TITLE
Message refactor

### DIFF
--- a/src/components/__tests__/__snapshots__/message.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/message.spec.tsx.snap
@@ -10,18 +10,17 @@ exports[`Message component should render 1`] = `
       class="message__side-border"
     />
     <test-file-stub
+      classname="message--icon-align-top"
       height="1.125em"
       width="1.125em"
     />
-    <section
-      class="message__content"
+    <div
+      class="message__title"
     >
-      <small>
-        <div>
-          Some content
-        </div>
-      </small>
-    </section>
+      <div>
+        Some content
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -36,18 +35,17 @@ exports[`Message component should render with a different level 1`] = `
       class="message__side-border"
     />
     <test-file-stub
+      classname="message--icon-align-top"
       height="1.125em"
       width="1.125em"
     />
-    <section
-      class="message__content"
+    <div
+      class="message__title"
     >
-      <small>
-        <div>
-          Some content
-        </div>
-      </small>
-    </section>
+      <div>
+        Some content
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -62,18 +60,17 @@ exports[`Message component should render with a subtitle 1`] = `
       class="message__side-border"
     />
     <test-file-stub
+      classname="message--icon-align-top"
       height="1.125em"
       width="1.125em"
     />
-    <section
-      class="message__content"
+    <div
+      class="message__title"
     >
-      <small>
-        <div>
-          Some content
-        </div>
-      </small>
-    </section>
+      <div>
+        Some content
+      </div>
+    </div>
     <div
       class="message__subtitle"
     >
@@ -94,15 +91,13 @@ exports[`Message component should render without default icon 1`] = `
     <div
       class="message__side-border"
     />
-    <section
-      class="message__content"
+    <div
+      class="message__title"
     >
-      <small>
-        <div>
-          Some content
-        </div>
-      </small>
-    </section>
+      <div>
+        Some content
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/__tests__/__snapshots__/message.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/message.spec.tsx.snap
@@ -82,6 +82,38 @@ exports[`Message component should render with a subtitle 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Message component should render with a title passed as prop 1`] = `
+<DocumentFragment>
+  <div
+    class="message message--info"
+    role="status"
+  >
+    <div
+      class="message__side-border"
+    />
+    <test-file-stub
+      classname="message--icon-align-center"
+      height="1.125em"
+      width="1.125em"
+    />
+    <div
+      class="message__title"
+    >
+      <h1>
+        Test
+      </h1>
+    </div>
+    <div
+      class="message__text"
+    >
+      <div>
+        Some content
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Message component should render without default icon 1`] = `
 <DocumentFragment>
   <div

--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
@@ -27,16 +27,15 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
       class="message__side-border"
     />
     <test-file-stub
+      classname="message--icon-align-top"
       height="1.125em"
       width="1.125em"
     />
-    <section
-      class="message__content"
+    <div
+      class="message__title"
     >
-      <small>
-        Your input contains 1 sequence
-      </small>
-    </section>
+      Your input contains 1 sequence
+    </div>
   </div>
   <div
     class="message message--failure"
@@ -47,19 +46,18 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
       class="message__side-border"
     />
     <test-file-stub
+      classname="message--icon-align-top"
       height="1.125em"
       width="1.125em"
     />
-    <section
-      class="message__content"
+    <div
+      class="message__title"
     >
-      <small>
-        <code>
-          sequence 1
-        </code>
-        : The sequence is invalid
-      </small>
-    </section>
+      <code>
+        sequence 1
+      </code>
+      : The sequence is invalid
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/__tests__/message.spec.tsx
+++ b/src/components/__tests__/message.spec.tsx
@@ -49,4 +49,13 @@ describe('Message component', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('should render with a title passed as prop', () => {
+    const { asFragment } = render(
+      <Message heading={<h1>Test</h1>}>
+        <div>Some content</div>
+      </Message>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -19,6 +19,10 @@ type Props = {
    */
   level?: 'warning' | 'failure' | 'success' | 'info';
   /**
+   * The title of the message
+   */
+  heading?: ReactNode;
+  /**
    * The content to appear underneath of the main message
    */
   subtitle?: ReactNode;
@@ -34,41 +38,55 @@ type Props = {
    * To hide the default box shadow
    */
   noShadow?: boolean;
-  /**
-   * To apply any specific styles required for messages shown in
-   * full-page error pages
-   */
-  forFullPage?: boolean;
 };
 
 const Message: FC<Props & HTMLAttributes<HTMLDivElement>> = ({
   children,
   level = 'info',
+  heading,
   subtitle,
   onDismiss,
   noIcon,
   noShadow,
-  forFullPage,
   className,
   ...props
 }) => {
   let maybeIcon = null;
-  if (!noIcon && !forFullPage) {
-    maybeIcon = <InformationIcon width={iconSize} height={iconSize} />;
+  const iconAlign = heading
+    ? 'message--icon-align-center'
+    : 'message--icon-align-top';
+
+  if (!noIcon) {
+    maybeIcon = (
+      <InformationIcon
+        width={iconSize}
+        height={iconSize}
+        className={iconAlign}
+      />
+    );
     if (level === 'warning') {
-      maybeIcon = <WarningTriangleIcon width={iconSize} height={iconSize} />;
+      maybeIcon = (
+        <WarningTriangleIcon
+          width={iconSize}
+          height={iconSize}
+          className={iconAlign}
+        />
+      );
     } else if (level === 'failure') {
-      maybeIcon = <ErrorIcon width={iconSize} height={iconSize} />;
+      maybeIcon = (
+        <ErrorIcon width={iconSize} height={iconSize} className={iconAlign} />
+      );
     } else if (level === 'success') {
-      maybeIcon = <SuccessIcon width={iconSize} height={iconSize} />;
+      maybeIcon = (
+        <SuccessIcon width={iconSize} height={iconSize} className={iconAlign} />
+      );
     }
   }
 
   return (
     <div
       className={cn(className, 'message', `message--${level}`, {
-        'message--no-shadow': noShadow || forFullPage,
-        'message--for-full-page': forFullPage,
+        'message--no-shadow': noShadow,
       })}
       role="status"
       {...props}
@@ -77,9 +95,20 @@ const Message: FC<Props & HTMLAttributes<HTMLDivElement>> = ({
 
       {maybeIcon}
 
-      <section className="message__content">
-        {forFullPage ? <h3>{children}</h3> : <small>{children}</small>}
-      </section>
+      {heading ? (
+        <>
+          <div
+            className={cn('message__title', {
+              'message__title--no-icon': noIcon,
+            })}
+          >
+            {heading}
+          </div>
+          <div className="message__text">{children}</div>
+        </>
+      ) : (
+        <div className="message__title">{children}</div>
+      )}
 
       {onDismiss && (
         <button type="button" className="message__dismiss" onClick={onDismiss}>

--- a/src/styles/components/message.scss
+++ b/src/styles/components/message.scss
@@ -22,14 +22,23 @@
 
   display: grid;
   grid-template-areas:
-    'border icon message dismiss'
-    '. . subtitle .';
+    'border icon title dismiss'
+    'border . text .'
+    'border . subtitle .';
   grid-template-columns: 1rem minmax(0, max-content) auto minmax(0, max-content);
+
+  &--icon-align-center {
+    align-self: center;
+  }
+
+  &--icon-align-top {
+    align-self: start;
+  }
 
   & > svg {
     grid-area: icon;
     height: 1.5rem;
-    align-self: center;
+    margin-right: 0.5rem;
   }
 
   &--no-shadow {
@@ -37,17 +46,21 @@
   }
 
   &__side-border {
+    grid-area: border;
     width: 0.25rem;
     height: auto;
   }
 
-  &__content {
-    padding-left: 0.5rem;
-    grid-area: message;
+  &__title {
+    grid-area: title;
 
-    & > h3 {
+    &--no-icon > * {
       color: $colour-weldon-blue;
     }
+  }
+
+  &__text {
+    grid-area: text;
   }
 
   &__subtitle {

--- a/stories/Message.stories.tsx
+++ b/stories/Message.stories.tsx
@@ -25,12 +25,12 @@ export const message = () => (
       'info',
       'Props'
     )}
+    heading={<h3>Lipsum generator</h3>}
     subtitle={text('subtitle', '', 'Props')}
     onDismiss={
       boolean('Dismissable', false, 'Props') ? action('Dismiss') : undefined
     }
-    forFullPage={boolean('forFullPage', false, 'Props')}
   >
-    {getLipsumSentences()}
+    <small>{getLipsumSentences()}</small>
   </Message>
 );


### PR DESCRIPTION
## Purpose
Separate the title and content in the message component and fix the icon placement when there is both title and text present or just text

Removed the full page option as it is no longer needed.

## Approach
How does this change address the problem?

## Testing
Added a test

## Stories
What story(ies) did you write or change to document the functionality / changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
