### PR TITLE
adjust z-index for sliding panel elements

### DIFF
--- a/src/styles/common/_z-index.scss
+++ b/src/styles/common/_z-index.scss
@@ -1,4 +1,5 @@
 $z-index-low: 2000;
 $z-index-medium: 5000;
 $z-index-high: 9000;
-$z-index-highest: 10000;
+//previous: $z-index-highest: 10000; current: max possible z-index
+$z-index-highest: 2147483647;


### PR DESCRIPTION
z-index-highest set to max as it is only used by sliding panels + ensure feedback button isn't covering panels

## Purpose
Describe the problem or feature in addition to a link to the issue(s), including context where needed.
UX issues with hotjar button as it is set to a high z-index. The biggest issues being the sliding panels on the right-hand side of the website; hotjar button can cover up delete icons, etc.

## Approach
How does this change address the problem?
$z-index-highest is only used by the sliding panels, so by making the z-index be the maximum possible, the sliding panel will cover all elements when called upon, including the hotjar feedback button and the contextual help button on the side.

## Testing
What test(s) did you write to validate and verify your changes?

## Stories
What story(ies) did you write or change to document the functionality / changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
