### PR TITLE
Improve message when duplicate sequences are entered

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "franklin-sites",
   "description": "React and Zurb Foundation based design system for life sciences web applications",
-  "version": "0.0.222",
+  "version": "0.0.223",
   "main": "dist/franklin-components.js",
   "files": [
     "src",

--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
@@ -53,10 +53,7 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
     <div
       class="message__title"
     >
-      <code>
-        sequence 1
-      </code>
-      : The sequence is invalid
+      Sequence 1 : The sequence is invalid
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
     <div
       class="message__title"
     >
-      Sequence 1 : The sequence is invalid
+      Error: The sequence is invalid. Sequence 1 
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/sequence-submission.tsx
+++ b/src/components/sequence-submission.tsx
@@ -95,7 +95,7 @@ const SequenceSubmission = ({
           data-testid="sequence-submission-error"
           key={sameErrors.map(({ sequenceIndex }) => sequenceIndex).join('-')}
         >
-          Sequence{sameErrors.length === 1 ? ' ' : 's '}
+          Error: {errorMessage}. Sequence{sameErrors.length === 1 ? ' ' : 's '}
           {sameErrors.map(
             ({ sequenceIndex, sequenceObject: { name } }, index) => (
               <Fragment key={sequenceIndex}>
@@ -111,7 +111,6 @@ const SequenceSubmission = ({
               </Fragment>
             )
           )}
-          : {errorMessage}
         </Message>
       );
     }


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-30482
Group all same sequences into one warning message instead of doing messages grouping them by pairs

## Approach
Use a map with the sequence as the key in order to detect duplicates

## Testing
Manual checks with the first 25 sequences from UniRef100_A0A087YSG4

## Stories
Sequence Submission

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
