### PR TITLE
Max min seq sub

### DIFF
--- a/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/sequence-submission.spec.tsx.snap
@@ -34,7 +34,7 @@ exports[`SequenceSubmission should render with sequence is invalid error 1`] = `
     <div
       class="message__title"
     >
-      Your input contains 1 sequence
+      Your input contains 1 sequence.
     </div>
   </div>
   <div

--- a/src/components/__tests__/sequence-submission.spec.tsx
+++ b/src/components/__tests__/sequence-submission.spec.tsx
@@ -4,6 +4,12 @@ import SequenceSubmission from '../sequence-submission';
 import { validResponse } from '../../sequence-utils/sequenceValidator';
 
 describe('SequenceSubmission', () => {
+  const multipleSequences = `> sequence_1
+ACTGUACTGUACTGU
+> sequence_2
+ACTGAUTTGUATTGUUUGU
+`;
+
   it('should render', () => {
     const { asFragment } = render(<SequenceSubmission />);
     expect(asFragment()).toMatchSnapshot();
@@ -46,5 +52,27 @@ describe('SequenceSubmission', () => {
         raw: value,
       },
     ]);
+  });
+
+  it('should render with too many sequences error', () => {
+    render(
+      <SequenceSubmission value={multipleSequences} maximumSequences={1} />
+    );
+    expect(
+      screen.getByText(
+        'Your input contains 2 sequences which exceeds the submission limit of 1.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('should render with too few sequences error', () => {
+    render(
+      <SequenceSubmission value={multipleSequences} minimumSequences={3} />
+    );
+    expect(
+      screen.getByText(
+        'Your input contains 2 sequences. At least 3 sequences are required.'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/sequence-submission.tsx
+++ b/src/components/sequence-submission.tsx
@@ -28,6 +28,14 @@ type Props = {
    * Minimum acceptable length for a sequence
    */
   minimumLength?: number;
+  /**
+   * Minimum acceptable number of sequences
+   */
+  minimumSequences?: number;
+  /**
+   * Maximum acceptable number of sequences
+   */
+  maximumSequences?: number;
 };
 
 const SequenceSubmission = ({
@@ -36,6 +44,8 @@ const SequenceSubmission = ({
   placeholder,
   defaultValue,
   minimumLength,
+  minimumSequences,
+  maximumSequences,
 }: Props) => {
   const [processed, setProcessed] = useState<SequenceObject[]>([]);
 
@@ -147,6 +157,29 @@ const SequenceSubmission = ({
     }
   }
 
+  const sequenceCountMessage =
+    (maximumSequences && processed.length > maximumSequences && (
+      <Message level="failure">
+        Your input contains {processed.length} sequences which exceeds the
+        submission limit of {maximumSequences}.
+      </Message>
+    )) ||
+    (minimumSequences &&
+      processed.length &&
+      processed.length < minimumSequences && (
+        <Message level="failure">
+          Your input contains {processed.length} sequence
+          {processed.length === 1 ? '' : 's'}. At least {minimumSequences}{' '}
+          sequences are required.
+        </Message>
+      )) ||
+    (processed[0] && processed[0].sequence.length > 10 && (
+      <Message level="info">
+        Your input contains {processed.length} sequence
+        {processed.length === 1 ? '' : 's'}.
+      </Message>
+    ));
+
   return (
     <>
       <textarea
@@ -158,12 +191,7 @@ const SequenceSubmission = ({
         defaultValue={defaultValue}
         spellCheck="false"
       />
-      {processed[0] && processed[0].sequence.length > 10 && (
-        <Message level="info">
-          Your input contains {processed.length} sequence
-          {processed.length === 1 ? '' : 's'}
-        </Message>
-      )}
+      {sequenceCountMessage}
       {errorMessages}
       {warningMessages}
     </>

--- a/stories/SequenceSubmission.stories.tsx
+++ b/stories/SequenceSubmission.stories.tsx
@@ -59,6 +59,37 @@ export const WithMultipleSequencesWarning: Story = {
   ),
 };
 
+const multipleSequences3 = `> sequence_1
+ACTGUACTGUACTGU`;
+export const WithTooFewSequencesError: Story = {
+  render: () => (
+    <SequenceSubmissionComponent
+      placeholder="Enter a sequence..."
+      defaultValue={multipleSequences3}
+      minimumSequences={2}
+    />
+  ),
+};
+
+const multipleSequences4 = `> sequence_1
+ACTGUACTGUACTGU
+> sequence_2
+ACTGAUTTGUATTGUUUGU
+> sequence_3
+ACTGCTGUAGU
+> sequence_4
+GUACTGU
+`;
+export const WithTooManySequencesError: Story = {
+  render: () => (
+    <SequenceSubmissionComponent
+      placeholder="Enter a sequence..."
+      defaultValue={multipleSequences4}
+      maximumSequences={3}
+    />
+  ),
+};
+
 const DynamicallyChangeValueRender = () => {
   const [sequence, setSequence] = useState('ACTG');
   const [likelyType, setLikelyType] = useState<SequenceObject['likelyType']>();


### PR DESCRIPTION
## Purpose
A user attempted to align ~1K sequences but couldn't click the submission button (because it exceeded the current limit of 50) and did not understand why. This PR will make it clearer to the user about min/max number of sequences.

## Approach
Update `SequenceSubmission` to accept optional `minimumSequences` and `maximumSequences` props which if they exist will check if user sequences are within bounds and if not display an error (rather than info) message. Otherwise default to info message with number of sequences.

## Testing
Updated

## Stories
Updated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [x] For the stories you created/updated, are the props modifiables through knobs?
