### PR TITLE
handle multiple identifiers and add error message

### DIFF
--- a/stories/SequenceSubmission.stories.tsx
+++ b/stories/SequenceSubmission.stories.tsx
@@ -90,6 +90,25 @@ export const WithTooManySequencesError: Story = {
   ),
 };
 
+const multipleSequences5 = `> sequence 1
+ACTGUACTGUACTGU
+> sequence 2
+ACTGAUTTGUATTGUUUGU
+> sequence 3
+ACTGCTGUAGU
+> sequence_4
+GUACTGU
+`;
+export const WithDuplicateIdentifiersError: Story = {
+  render: () => (
+    <SequenceSubmissionComponent
+      placeholder="Enter a sequence..."
+      defaultValue={multipleSequences5}
+      noDuplicateID
+    />
+  ),
+};
+
 const DynamicallyChangeValueRender = () => {
   const [sequence, setSequence] = useState('ACTG');
   const [likelyType, setLikelyType] = useState<SequenceObject['likelyType']>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3625,9 +3625,9 @@ camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001669:
-  version "1.0.30001674"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001674.tgz#eb200a716c3e796d33d30b9c8890517a72f862c8"
-  integrity sha512-jOsKlZVRnzfhLojb+Ykb+gyUSp9Xb57So+fAiFlLzzTKpqg8xxSav0e40c8/4F/v9N8QSvrRRaLeVzQbLqomYw==
+  version "1.0.30001724"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001724.tgz"
+  integrity sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## Purpose
[TRM-32812](https://embl.atlassian.net/browse/TRM-32812)Add error messages when using duplicate identifiers, make that optional (it's only for Clustal Omega / Align)

## Approach
Similar way as the logic for duplicate sequences, but optional, and if displaying a message display as failure and change a bit the wording

## Testing
Manual tests + added a story with that case

## Stories
New story specifically for this

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] Were all the edited/created files in TypeScript? If not, please list the files you left in JavaScript and the reason to not update them.
- [ ] For the stories you created/updated, are the props modifiables through knobs?
